### PR TITLE
Quick patch - refactor followup

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "NODE_ENV=development lerna run test --stream"
   },
   "devDependencies": {
+    "@babel/core": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
     "@types/jest": "^28.1.4",
     "@types/node": "^15.6.2",

--- a/packages/ws-relay/build.js
+++ b/packages/ws-relay/build.js
@@ -1,0 +1,9 @@
+require('esbuild')
+  .build({
+    logLevel: 'info',
+    entryPoints: ['src/index.ts', 'src/bin.ts'],
+    bundle: true,
+    outdir: 'dist',
+    platform: 'node',
+  })
+  .catch(() => process.exit(1))

--- a/packages/ws-relay/package.json
+++ b/packages/ws-relay/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.ts",
   "bin": "dist/bin.js",
   "scripts": {
-    "build": "tsc",
+    "build": "node build.js",
     "dev": "nodemon ./src/bin.ts",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
   integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.17.10":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.17.10", "@babel/core@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.6.tgz#54a107a3c298aee3fe5e1947a6464b9b6faca03d"
   integrity sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==


### PR DESCRIPTION
Quick patch for the build script for `ws-relay`
and adding in missing peer dependency `@babel/core`