### PR TITLE
fixed package exports

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/auth",
   "version": "0.0.3",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest",
     "prettier": "prettier --check src/",

--- a/packages/awake/package.json
+++ b/packages/awake/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/awake",
   "version": "0.0.2",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "engines": {
     "node": ">=16"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/common",
   "version": "0.0.1",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest",
     "prettier": "prettier --check src/",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/crypto",
   "version": "0.0.1",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest ",
     "prettier": "prettier --check src/",

--- a/packages/did-sdk/package.json
+++ b/packages/did-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/did-sdk",
   "version": "0.0.1",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "test": "jest",
     "prettier": "prettier --check src/",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/server",
   "version": "0.0.2",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "build": "node ./build.js",
     "start": "node dist/index.js",

--- a/packages/ws-relay/package.json
+++ b/packages/ws-relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adxp/ws-relay",
   "version": "0.0.1",
-  "main": "dist/index.ts",
+  "main": "src/index.ts",
   "bin": "dist/bin.js",
   "scripts": {
     "build": "node build.js",


### PR DESCRIPTION
I was exporting `dist/index.js` in most packages.

We want to export `src/index.ts` so that esbuild can build in the original typescript. This also fixes issues with jest running.

We'll need to figure out how to set this to `dist/index.js` on publish.

This can probably be done w a publishing script or by using pnpm's `publishConfig` feature ([as seen here](https://github.com/CryogenicPlanet/typescript-monorepo-example/blob/master/packages/package-a/package.json#L22)). But this would require using pnpm instead of yarn