### PR TITLE
Quick auth lobby fix

### DIFF
--- a/packages/auth/src/auth-store.ts
+++ b/packages/auth/src/auth-store.ts
@@ -113,7 +113,7 @@ export class AuthStore implements Signer {
   // Mainly for dev purposes
   async claimFull(): Promise<ucan.Ucan> {
     const keypair = await this.getKeypair()
-    const ownDid = keypair.did()
+    const ownDid = await this.did()
     const token = await ucan
       .createBuilder()
       .issuedBy(keypair)

--- a/packages/auth/src/browser-store.ts
+++ b/packages/auth/src/browser-store.ts
@@ -33,6 +33,7 @@ export class BrowserStore extends AuthStore {
     const keypair = await crypto.EcdsaKeypair.import(jwk, {
       exportable: true,
     })
+    localStorage.setItem('adxKey', JSON.stringify(jwk))
     const storedUcans = BrowserStore.getStoredUcanStrs()
     const ucanStore = await ucan.storeFromTokens(adxSemantics, storedUcans)
     const authStore = new BrowserStore(keypair, ucanStore)
@@ -54,9 +55,9 @@ export class BrowserStore extends AuthStore {
   }
 
   async addUcan(token: ucan.Ucan): Promise<void> {
-    this.ucanStore.add(token)
     const storedUcans = BrowserStore.getStoredUcanStrs()
     BrowserStore.setStoredUcanStrs([...storedUcans, ucan.encode(token)])
+    await this.ucanStore.add(token)
   }
 
   async getUcanStore(): Promise<ucan.Store> {


### PR DESCRIPTION
Found a couple of sneaky bois 🐛  lurking in the auth lobby code

- A missing `await` when adding a ucan that caused the auth check to fail even though the token should've been there
- not persisting the key for the root device, so it was loading a new key when refreshing an already logged in root device