### PR TITLE
Add better cursor pagination behavior to getFeed

### DIFF
--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -645,6 +645,9 @@ export const methodSchemas: MethodSchema[] = [
               'indexedAt',
             ],
             properties: {
+              cursor: {
+                type: 'string',
+              },
               uri: {
                 type: 'string',
               },

--- a/packages/api/src/types/todo/social/getFeed.ts
+++ b/packages/api/src/types/todo/social/getFeed.ts
@@ -19,6 +19,7 @@ export interface OutputSchema {
   feed: FeedItem[];
 }
 export interface FeedItem {
+  cursor?: string;
   uri: string;
   author: User;
   repostedBy?: User;

--- a/packages/server/src/api/todo/social/getFeed.ts
+++ b/packages/server/src/api/todo/social/getFeed.ts
@@ -107,11 +107,11 @@ export default function (server: Server) {
           `requester_like.creator = :requester AND requester_like.subject = post.uri`,
           { requester },
         )
-        .orderBy('post.createdAt', 'DESC')
+        .orderBy('post.indexedAt', 'DESC')
         .groupBy('post.uri')
 
       if (before !== undefined) {
-        builder.andWhere('post.createdAt < :before', { before })
+        builder.andWhere('post.indexedAt < :before', { before })
       }
       if (limit !== undefined) {
         builder.limit(limit)
@@ -121,6 +121,7 @@ export default function (server: Server) {
 
       // @TODO add embeds
       const feed: GetFeed.FeedItem[] = queryRes.map((row) => ({
+        cursor: row.indexedAt,
         uri: row.uri,
         author: {
           did: row.authorDid,

--- a/packages/server/src/lexicon/schemas.ts
+++ b/packages/server/src/lexicon/schemas.ts
@@ -645,6 +645,9 @@ export const methodSchemas: MethodSchema[] = [
               'indexedAt',
             ],
             properties: {
+              cursor: {
+                type: 'string',
+              },
               uri: {
                 type: 'string',
               },

--- a/packages/server/src/lexicon/types/todo/social/getFeed.ts
+++ b/packages/server/src/lexicon/types/todo/social/getFeed.ts
@@ -27,6 +27,7 @@ export interface OutputSchema {
   feed: FeedItem[];
 }
 export interface FeedItem {
+  cursor?: string;
   uri: string;
   author: User;
   repostedBy?: User;

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -374,6 +374,17 @@ describe('pds views', () => {
     expect(aliceFeed.data.feed[6].record.text).toEqual(posts.bob[0])
     expect(aliceFeed.data.feed[3].repostCount).toEqual(1)
 
+    const aliceFeed2 = await client.todo.social.getFeed(
+      { before: aliceFeed.data.feed[0].cursor, limit: 1 },
+      undefined,
+      {
+        headers: getHeaders(users.alice.did),
+      },
+    )
+    expect(aliceFeed2.data.feed.length).toBe(1)
+    /** @ts-ignore TODO */
+    expect(aliceFeed2.data.feed[0].record.text).toEqual(replies.bob[0])
+
     const bobFeed = await client.todo.social.getFeed({}, undefined, {
       headers: getHeaders(users.bob.did),
     })
@@ -417,6 +428,16 @@ describe('pds views', () => {
     expect(aliceFeed.data.feed[2].record.text).toEqual(posts.alice[1])
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed[3].record.text).toEqual(posts.alice[0])
+
+    const aliceFeed2 = await client.todo.social.getFeed(
+      { author: 'alice.test', before: aliceFeed.data.feed[0].cursor, limit: 1 },
+      undefined,
+      {
+        headers: getHeaders(users.bob.did),
+      },
+    )
+    /** @ts-ignore TODO */
+    expect(aliceFeed2.data.feed[0].record.text).toEqual(posts.alice[2])
 
     const carolFeed = await client.todo.social.getFeed(
       { author: 'carol.test' },

--- a/schemas/todo.social/getFeed.json
+++ b/schemas/todo.social/getFeed.json
@@ -24,6 +24,7 @@
           "type": "object",
           "required": ["uri", "author", "record", "replyCount", "repostCount", "likeCount", "indexedAt"],
           "properties": {
+            "cursor": {"type": "string"},
             "uri": {"type": "string"},
             "author": {"$ref": "#/$defs/user"},
             "repostedBy": {"$ref": "#/$defs/user"},


### PR DESCRIPTION
- Adds a `cursor` field to items returned by `todo.social.getFeed`
- Internally switches to ordering by indexedAt (needs to eventually be rtime probably)

This change basically makes it unambiguous what to pass into the `before` param when using getFeed. I'd suggest using this pattern or similar any time we need pagination in APIs.