### PR TITLE
Feed bugfixes

### DIFF
--- a/packages/server/src/api/todo/social/getFeed.ts
+++ b/packages/server/src/api/todo/social/getFeed.ts
@@ -38,16 +38,17 @@ export default function (server: Server) {
           .where('user.did = :did', { did: requester })
       } else {
         const authorWhere = author.startsWith('did:')
-          ? 'author.did'
-          : 'author.username'
+          ? 'originator.did'
+          : 'originator.username'
         builder
           .from(PostIndex, 'post')
           .leftJoin(RepostIndex, 'repost', 'repost.subject = post.uri')
           .leftJoin(
             User,
-            'author',
-            'author.did = post.creator OR author.did = repost.creator',
+            'originator',
+            'originator.did = post.creator OR originator.did = repost.creator',
           )
+          .leftJoin(User, 'author', 'author.did = post.creator')
           .where(`${authorWhere} = :author`, { author })
       }
 
@@ -60,6 +61,9 @@ export default function (server: Server) {
           'reposted_by.did AS repostedByDid',
           'reposted_by.username AS repostedByName',
           'reposted_by_profile.displayName AS repostedByDisplayName',
+          author === undefined
+            ? 'follow.subject == post.creator AS isNotRepost'
+            : 'originator.did == post.creator as isNotRepost',
           'record.raw AS rawRecord',
           'like_count.count AS likeCount',
           'repost_count.count AS repostCount',
@@ -128,13 +132,14 @@ export default function (server: Server) {
           name: row.authorName,
           displayName: row.authorDisplayName || undefined,
         },
-        repostedBy: row.repostedByDid
-          ? {
-              did: row.repostedByDid,
-              name: row.repostedByName,
-              displayName: row.repostedByDisplayName || undefined,
-            }
-          : undefined,
+        repostedBy:
+          !row.isNotRepost && row.repostedByDid
+            ? {
+                did: row.repostedByDid,
+                name: row.repostedByName,
+                displayName: row.repostedByDisplayName || undefined,
+              }
+            : undefined,
         record: JSON.parse(row.rawRecord),
         replyCount: row.replyCount || 0,
         repostCount: row.repostCount || 0,

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -376,7 +376,15 @@ describe('pds views', () => {
     expect(aliceFeed.data.feed[5].record.text).toEqual(posts.carol[0])
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed[6].record.text).toEqual(posts.bob[0])
-    expect(aliceFeed.data.feed[3].repostCount).toEqual(1)
+    for (let i = 0; i < aliceFeed.data.feed.length; i++) {
+      if (i === 3) {
+        expect(aliceFeed.data.feed[i].repostCount).toEqual(1)
+        expect(aliceFeed.data.feed[i].repostedBy?.name).toBe('carol.test')
+      } else {
+        expect(aliceFeed.data.feed[i].repostCount).toEqual(0)
+        expect(aliceFeed.data.feed[i].repostedBy).toBeUndefined()
+      }
+    }
 
     const aliceFeed2 = await client.todo.social.getFeed(
       { before: aliceFeed.data.feed[0].cursor, limit: 1 },

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -155,7 +155,7 @@ describe('pds views', () => {
       )
       return new AdxUri(res.uri)
     }
-    bobLikes[alicePosts[2].toString()] = await like(
+    bobLikes[alicePosts[1].toString()] = await like(
       users.bob.did,
       alicePosts[1].toString(),
     )
@@ -411,7 +411,7 @@ describe('pds views', () => {
     expect(bobFeed.data.feed[3].likeCount).toEqual(3)
     expect(bobFeed.data.feed[2].likeCount).toEqual(2)
     expect(bobFeed.data.feed[3]?.myState?.like).toEqual(
-      bobLikes[alicePosts[1].toString()],
+      bobLikes[alicePosts[1].toString()].toString(),
     )
     expect(bobFeed.data.feed[6]?.myState?.like).toBeUndefined()
   })


### PR DESCRIPTION
Mainly fixes an issue where the `repostedBy` information would be incorrectly populated on non-reposts