### PR TITLE
Fixes for handling of posts vs. reposts in feeds

### DIFF
--- a/packages/server/src/api/todo/social/getAuthorFeed.ts
+++ b/packages/server/src/api/todo/social/getAuthorFeed.ts
@@ -8,6 +8,7 @@ import {
   queryPostsWithReposts,
   queryResultToFeedItem,
 } from './util'
+import { postOrRepostIndexedAtClause } from '../../../db/util'
 
 export default function (server: Server) {
   server.todo.social.getAuthorFeed(
@@ -32,13 +33,14 @@ export default function (server: Server) {
       })
 
       // Select data for presentation into FeedItem
-      queryPostsAndRepostsAsFeedItems(builder, { requester })
-        .orderBy('post.indexedAt', 'DESC')
-        .groupBy('post.uri')
+      queryPostsAndRepostsAsFeedItems(builder, { requester }).groupBy(
+        'post.uri',
+      )
 
       // Apply pagination
+      builder.orderBy(postOrRepostIndexedAtClause, 'DESC')
       if (before !== undefined) {
-        builder.andWhere('post.indexedAt < :before', { before })
+        builder.andWhere(`${postOrRepostIndexedAtClause} < :before`, { before })
       }
       if (limit !== undefined) {
         builder.limit(limit)

--- a/packages/server/src/api/todo/social/getAuthorFeed.ts
+++ b/packages/server/src/api/todo/social/getAuthorFeed.ts
@@ -33,9 +33,11 @@ export default function (server: Server) {
       })
 
       // Select data for presentation into FeedItem
-      queryPostsAndRepostsAsFeedItems(builder, { requester }).groupBy(
-        'post.uri',
-      )
+      queryPostsAndRepostsAsFeedItems(builder, { requester })
+        // Grouping by post then originator preserves one row for each
+        // post or repost. Reposts of a given post only vary by originator.
+        .groupBy('post.uri')
+        .addGroupBy('originator.did')
 
       // Apply pagination
       builder.orderBy(postOrRepostIndexedAtClause, 'DESC')

--- a/packages/server/src/api/todo/social/getHomeFeed.ts
+++ b/packages/server/src/api/todo/social/getHomeFeed.ts
@@ -59,9 +59,11 @@ export default function (server: Server) {
       }
 
       // Select data for presentation into FeedItem
-      queryPostsAndRepostsAsFeedItems(builder, { requester }).groupBy(
-        'post.uri',
-      )
+      queryPostsAndRepostsAsFeedItems(builder, { requester })
+        // Grouping by post then originator preserves one row for each
+        // post or repost. Reposts of a given post only vary by originator.
+        .groupBy('post.uri')
+        .addGroupBy('originator.did')
 
       // Apply pagination
       builder.orderBy(postOrRepostIndexedAtClause, 'DESC')

--- a/packages/server/src/api/todo/social/getHomeFeed.ts
+++ b/packages/server/src/api/todo/social/getHomeFeed.ts
@@ -12,6 +12,7 @@ import {
   queryPostsWithReposts,
   queryResultToFeedItem,
 } from './util'
+import { postOrRepostIndexedAtClause } from '../../../db/util'
 
 export default function (server: Server) {
   server.todo.social.getHomeFeed(
@@ -58,13 +59,14 @@ export default function (server: Server) {
       }
 
       // Select data for presentation into FeedItem
-      queryPostsAndRepostsAsFeedItems(builder, { requester })
-        .orderBy('post.indexedAt', 'DESC')
-        .groupBy('post.uri')
+      queryPostsAndRepostsAsFeedItems(builder, { requester }).groupBy(
+        'post.uri',
+      )
 
       // Apply pagination
+      builder.orderBy(postOrRepostIndexedAtClause, 'DESC')
       if (before !== undefined) {
-        builder.andWhere('post.indexedAt < :before', { before })
+        builder.andWhere(`${postOrRepostIndexedAtClause} < :before`, { before })
       }
       if (limit !== undefined) {
         builder.limit(limit)

--- a/packages/server/src/api/todo/social/getHomeFeed.ts
+++ b/packages/server/src/api/todo/social/getHomeFeed.ts
@@ -12,7 +12,10 @@ import {
   queryPostsWithReposts,
   queryResultToFeedItem,
 } from './util'
-import { postOrRepostIndexedAtClause } from '../../../db/util'
+import {
+  isNotRepostClause,
+  postOrRepostIndexedAtClause,
+} from '../../../db/util'
 
 export default function (server: Server) {
   server.todo.social.getHomeFeed(
@@ -34,14 +37,17 @@ export default function (server: Server) {
         throw new InvalidRequestError(`Unsupported algorithm: ${algorithm}`)
       }
 
-      // Posts by or reposted by a follower of requester, and not by requester.
-
       const builder = db.db.createQueryBuilder().from(PostIndex, 'post')
 
       // Determine result set of posts and reposts
       if (feedAlgorithm === FeedAlgorithm.Firehose) {
-        queryPostsWithReposts(builder)
+        // All posts, except requester's reposts
+        queryPostsWithReposts(builder).where(
+          `post.creator != :requester or ${isNotRepostClause}`,
+          { requester },
+        )
       } else if (feedAlgorithm === FeedAlgorithm.ReverseChronological) {
+        // Followee's posts and reposts, and requester's posts
         const followingIdsSubquery = (qb: SelectQueryBuilder<PostIndex>) => {
           return qb
             .subQuery()
@@ -51,8 +57,18 @@ export default function (server: Server) {
             .getQuery()
         }
         queryPostsWithReposts(builder)
-          .where((qb) => `originator.did IN ${followingIdsSubquery(qb)}`)
-          .andWhere('post.creator != :requester', { requester })
+          .where(`(post.creator != :requester or ${isNotRepostClause})`, {
+            requester,
+          })
+          .andWhere(
+            (qb) => {
+              return (
+                `(originator.did IN ${followingIdsSubquery(qb)} or ` +
+                `originator.did = :requester)`
+              )
+            },
+            { requester },
+          )
       } else {
         const exhaustiveCheck: never = feedAlgorithm
         throw new Error(`Unhandled case: ${exhaustiveCheck}`)

--- a/packages/server/src/api/todo/social/util.ts
+++ b/packages/server/src/api/todo/social/util.ts
@@ -46,9 +46,6 @@ export const queryPostsWithReposts = (qb: SelectQueryBuilder<PostIndex>) => {
     .leftJoin(
       User,
       'originator',
-      // @TODO this combined with the groupBy('post.uri') makes the result not well-defined
-      // when a post and its repost both could appear in the feed. You may get just the post,
-      // or you may just get the repost.
       'originator.did = post.creator OR originator.did = repost.creator',
     )
 }
@@ -68,7 +65,7 @@ export const queryPostsAndRepostsAsFeedItems = (
       'reposted_by.did AS repostedByDid',
       'reposted_by.username AS repostedByName',
       'reposted_by_profile.displayName AS repostedByDisplayName',
-      'originator.did == post.creator AS isNotRepost',
+      `${util.isNotRepostClause} AS isNotRepost`,
       'record.raw AS rawRecord',
       'like_count.count AS likeCount',
       'repost_count.count AS repostCount',

--- a/packages/server/src/api/todo/social/util.ts
+++ b/packages/server/src/api/todo/social/util.ts
@@ -75,6 +75,7 @@ export const queryPostsAndRepostsAsFeedItems = (
       'requester_repost.uri AS requesterRepost',
       'requester_like.uri AS requesterLike',
       'record.indexedAt AS indexedAt',
+      `${util.postOrRepostIndexedAtClause} as cursor`,
     ])
     .leftJoin(User, 'author', 'author.did = post.creator')
     .leftJoin(
@@ -123,7 +124,7 @@ export const queryPostsAndRepostsAsFeedItems = (
 export const queryResultToFeedItem = (
   row,
 ): TodoSocialGetHomeFeed.FeedItem & TodoSocialGetAuthorFeed.FeedItem => ({
-  cursor: row.indexedAt,
+  cursor: row.cursor,
   uri: row.uri,
   author: {
     did: row.authorDid,

--- a/packages/server/src/api/todo/social/util.ts
+++ b/packages/server/src/api/todo/social/util.ts
@@ -53,7 +53,8 @@ export const queryPostsWithReposts = (qb: SelectQueryBuilder<PostIndex>) => {
     )
 }
 
-// Select data for presentation of posts and reposts into FeedItems
+// Select data for presentation of posts and reposts into FeedItems.
+// NOTE ensure each join matches 0 or 1 rows, does not cause duplication of (re-)posts.
 export const queryPostsAndRepostsAsFeedItems = (
   qb: SelectQueryBuilder<PostIndex>,
   { requester },

--- a/packages/server/src/db/util.ts
+++ b/packages/server/src/db/util.ts
@@ -13,8 +13,9 @@ export const userWhereClause = (user: string): string => {
   }
 }
 
-export const postOrRepostIndexedAtClause =
-  'iif(originator.did == post.creator, post.indexedAt, repost.indexedAt)'
+export const isNotRepostClause = 'originator.did == post.creator'
+
+export const postOrRepostIndexedAtClause = `iif(${isNotRepostClause}, post.indexedAt, repost.indexedAt)`
 
 type Subquery = (qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>
 

--- a/packages/server/src/db/util.ts
+++ b/packages/server/src/db/util.ts
@@ -13,6 +13,9 @@ export const userWhereClause = (user: string): string => {
   }
 }
 
+export const postOrRepostIndexedAtClause =
+  'coalesce(repost.indexedAt, post.indexedAt)'
+
 type Subquery = (qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>
 
 export const countSubquery = (

--- a/packages/server/src/db/util.ts
+++ b/packages/server/src/db/util.ts
@@ -14,7 +14,7 @@ export const userWhereClause = (user: string): string => {
 }
 
 export const postOrRepostIndexedAtClause =
-  'coalesce(repost.indexedAt, post.indexedAt)'
+  'iif(originator.did == post.creator, post.indexedAt, repost.indexedAt)'
 
 type Subquery = (qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>
 

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -372,27 +372,38 @@ describe('pds views', () => {
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
       posts.dan[1], // Repost
+      replies.alice[0],
       replies.carol[0],
       replies.bob[0],
+      posts.alice[2],
       posts.bob[1],
+      posts.alice[1],
       posts.dan[1], // Original post
       posts.dan[0],
       posts.carol[0],
       posts.bob[0],
+      posts.alice[0],
     ])
 
-    for (let i = 0; i < aliceFeed.data.feed.length; i++) {
-      if (i === 0) {
-        expect(aliceFeed.data.feed[i].repostCount).toEqual(1)
-        expect(aliceFeed.data.feed[i].repostedBy?.name).toBe('carol.test')
-      } else if (i === 4) {
-        expect(aliceFeed.data.feed[i].repostCount).toEqual(1)
-        expect(aliceFeed.data.feed[i].repostedBy).toBeUndefined()
-      } else {
-        expect(aliceFeed.data.feed[i].repostCount).toEqual(0)
-        expect(aliceFeed.data.feed[i].repostedBy).toBeUndefined()
-      }
-    }
+    const toRepostInfo = (item) => ({
+      repostCount: item.repostCount,
+      repostedByName: item.repostedBy?.name,
+    })
+
+    expect(aliceFeed.data.feed.map(toRepostInfo)).toEqual([
+      { repostCount: 1, repostedByName: 'carol.test' },
+      { repostCount: 0 },
+      { repostCount: 0 },
+      { repostCount: 0 },
+      { repostCount: 0 },
+      { repostCount: 0 },
+      { repostCount: 1 },
+      { repostCount: 1 },
+      { repostCount: 0 },
+      { repostCount: 0 },
+      { repostCount: 0 },
+      { repostCount: 0 },
+    ])
 
     const aliceFeed2 = await client.todo.social.getHomeFeed(
       {
@@ -407,7 +418,7 @@ describe('pds views', () => {
     )
     /** @ts-ignore TODO */
     expect(aliceFeed2.data.feed.map((item) => item.record.text)).toEqual([
-      replies.carol[0],
+      replies.alice[0],
     ])
 
     const bobFeed = await client.todo.social.getHomeFeed(
@@ -423,19 +434,22 @@ describe('pds views', () => {
       posts.dan[1],
       replies.alice[0],
       replies.carol[0],
+      replies.bob[0],
       posts.alice[2],
+      posts.bob[1],
       posts.alice[1],
       posts.carol[0],
+      posts.bob[0],
       posts.alice[0],
     ])
 
-    expect(bobFeed.data.feed[4].replyCount).toEqual(2)
-    expect(bobFeed.data.feed[4].likeCount).toEqual(3)
-    expect(bobFeed.data.feed[3].likeCount).toEqual(2)
-    expect(bobFeed.data.feed[4]?.myState?.like).toEqual(
+    expect(bobFeed.data.feed[6].replyCount).toEqual(2)
+    expect(bobFeed.data.feed[6].likeCount).toEqual(3)
+    expect(bobFeed.data.feed[4].likeCount).toEqual(2)
+    expect(bobFeed.data.feed[6]?.myState?.like).toEqual(
       bobLikes[alicePosts[1].toString()].toString(),
     )
-    expect(bobFeed.data.feed[6]?.myState?.like).toBeUndefined()
+    expect(bobFeed.data.feed[9]?.myState?.like).toBeUndefined()
   })
 
   it("fetches authenticated user's home feed w/ firehose algorithm", async () => {
@@ -449,7 +463,6 @@ describe('pds views', () => {
 
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
-      posts.alice[1], // Repost
       posts.dan[1], // Repost
       replies.alice[0],
       replies.carol[0],

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -371,19 +371,19 @@ describe('pds views', () => {
 
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
+      posts.dan[1],
       replies.carol[0],
       replies.bob[0],
       posts.bob[1],
-      posts.dan[1],
       posts.dan[0],
       posts.carol[0],
       posts.bob[0],
     ])
 
     for (let i = 0; i < aliceFeed.data.feed.length; i++) {
-      if (i === 3) {
+      if (i === 0) {
         expect(aliceFeed.data.feed[i].repostCount).toEqual(1)
-        expect(aliceFeed.data.feed[i].repostedBy?.name).toBe('carol.test')
+        // @TODO fix groupBy() expect(aliceFeed.data.feed[i].repostedBy?.name).toBe('carol.test')
       } else {
         expect(aliceFeed.data.feed[i].repostCount).toEqual(0)
         expect(aliceFeed.data.feed[i].repostedBy).toBeUndefined()
@@ -401,9 +401,10 @@ describe('pds views', () => {
         headers: getHeaders(users.alice.did),
       },
     )
-    expect(aliceFeed2.data.feed.length).toBe(1)
     /** @ts-ignore TODO */
-    expect(aliceFeed2.data.feed[0].record.text).toEqual(replies.bob[0])
+    expect(aliceFeed2.data.feed.map((item) => item.record.text)).toEqual([
+      replies.carol[0],
+    ])
 
     const bobFeed = await client.todo.social.getHomeFeed(
       { algorithm: FeedAlgorithm.ReverseChronological },
@@ -414,20 +415,20 @@ describe('pds views', () => {
     )
 
     /** @ts-ignore TODO */
-    expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
+    expect(bobFeed.data.feed.map((item) => item.record.text)).toEqual([
+      posts.alice[1],
+      posts.dan[1],
       replies.alice[0],
       replies.carol[0],
       posts.alice[2],
-      posts.alice[1],
-      posts.dan[1],
       posts.carol[0],
       posts.alice[0],
     ])
 
-    expect(bobFeed.data.feed[3].replyCount).toEqual(2)
-    expect(bobFeed.data.feed[3].likeCount).toEqual(3)
-    expect(bobFeed.data.feed[2].likeCount).toEqual(2)
-    expect(bobFeed.data.feed[3]?.myState?.like).toEqual(
+    expect(bobFeed.data.feed[0].replyCount).toEqual(2)
+    expect(bobFeed.data.feed[0].likeCount).toEqual(3)
+    expect(bobFeed.data.feed[4].likeCount).toEqual(2)
+    expect(bobFeed.data.feed[0]?.myState?.like).toEqual(
       bobLikes[alicePosts[1].toString()].toString(),
     )
     expect(bobFeed.data.feed[6]?.myState?.like).toBeUndefined()
@@ -444,25 +445,25 @@ describe('pds views', () => {
 
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
+      posts.alice[1],
+      posts.dan[1],
       replies.alice[0],
       replies.carol[0],
       replies.bob[0],
       posts.alice[2],
       posts.bob[1],
-      posts.alice[1],
-      posts.dan[1],
       posts.dan[0],
       posts.carol[0],
       posts.bob[0],
       posts.alice[0],
     ])
 
-    const indexedAts = aliceFeed.data.feed.map((item) => item.indexedAt)
-    const orderedIndexedAts = [...indexedAts].sort(
+    const cursors = aliceFeed.data.feed.map((item) => item.cursor)
+    const orderedCursors = [...cursors].sort(
       (a, b) => new Date(b).getTime() - new Date(a).getTime(),
     )
 
-    expect(indexedAts).toEqual(orderedIndexedAts)
+    expect(cursors).toEqual(orderedCursors)
   })
 
   it("fetches authenticated user's home feed w/ default algorithm", async () => {
@@ -488,13 +489,12 @@ describe('pds views', () => {
       },
     )
     /** @ts-ignore TODO */
-    expect(aliceFeed.data.feed[0].record.text).toEqual(replies.alice[0])
-    /** @ts-ignore TODO */
-    expect(aliceFeed.data.feed[1].record.text).toEqual(posts.alice[2])
-    /** @ts-ignore TODO */
-    expect(aliceFeed.data.feed[2].record.text).toEqual(posts.alice[1])
-    /** @ts-ignore TODO */
-    expect(aliceFeed.data.feed[3].record.text).toEqual(posts.alice[0])
+    expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
+      posts.alice[1],
+      replies.alice[0],
+      posts.alice[2],
+      posts.alice[0],
+    ])
 
     const aliceFeed2 = await client.todo.social.getAuthorFeed(
       { author: 'alice.test', before: aliceFeed.data.feed[0].cursor, limit: 1 },
@@ -504,7 +504,9 @@ describe('pds views', () => {
       },
     )
     /** @ts-ignore TODO */
-    expect(aliceFeed2.data.feed[0].record.text).toEqual(posts.alice[2])
+    expect(aliceFeed2.data.feed.map((item) => item.record.text)).toEqual([
+      replies.alice[0],
+    ])
 
     const carolFeed = await client.todo.social.getAuthorFeed(
       { author: 'carol.test' },
@@ -514,11 +516,11 @@ describe('pds views', () => {
       },
     )
     /** @ts-ignore TODO */
-    expect(carolFeed.data.feed[0].record.text).toEqual(replies.carol[0])
-    /** @ts-ignore TODO */
-    expect(carolFeed.data.feed[1].record.text).toEqual(posts.dan[1])
-    /** @ts-ignore TODO */
-    expect(carolFeed.data.feed[2].record.text).toEqual(posts.carol[0])
+    expect(carolFeed.data.feed.map((item) => item.record.text)).toEqual([
+      posts.dan[1],
+      replies.carol[0],
+      posts.carol[0],
+    ])
   })
 
   it('fetches postThread', async () => {

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import AdxApi, { ServiceClient as AdxServiceClient } from '@adxp/api'
 import { AdxUri } from '@adxp/uri'
 import { users, posts, replies } from './test-data'

--- a/packages/server/tests/views.test.ts
+++ b/packages/server/tests/views.test.ts
@@ -371,10 +371,11 @@ describe('pds views', () => {
 
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
-      posts.dan[1],
+      posts.dan[1], // Repost
       replies.carol[0],
       replies.bob[0],
       posts.bob[1],
+      posts.dan[1], // Original post
       posts.dan[0],
       posts.carol[0],
       posts.bob[0],
@@ -383,7 +384,10 @@ describe('pds views', () => {
     for (let i = 0; i < aliceFeed.data.feed.length; i++) {
       if (i === 0) {
         expect(aliceFeed.data.feed[i].repostCount).toEqual(1)
-        // @TODO fix groupBy() expect(aliceFeed.data.feed[i].repostedBy?.name).toBe('carol.test')
+        expect(aliceFeed.data.feed[i].repostedBy?.name).toBe('carol.test')
+      } else if (i === 4) {
+        expect(aliceFeed.data.feed[i].repostCount).toEqual(1)
+        expect(aliceFeed.data.feed[i].repostedBy).toBeUndefined()
       } else {
         expect(aliceFeed.data.feed[i].repostCount).toEqual(0)
         expect(aliceFeed.data.feed[i].repostedBy).toBeUndefined()
@@ -416,19 +420,19 @@ describe('pds views', () => {
 
     /** @ts-ignore TODO */
     expect(bobFeed.data.feed.map((item) => item.record.text)).toEqual([
-      posts.alice[1],
       posts.dan[1],
       replies.alice[0],
       replies.carol[0],
       posts.alice[2],
+      posts.alice[1],
       posts.carol[0],
       posts.alice[0],
     ])
 
-    expect(bobFeed.data.feed[0].replyCount).toEqual(2)
-    expect(bobFeed.data.feed[0].likeCount).toEqual(3)
-    expect(bobFeed.data.feed[4].likeCount).toEqual(2)
-    expect(bobFeed.data.feed[0]?.myState?.like).toEqual(
+    expect(bobFeed.data.feed[4].replyCount).toEqual(2)
+    expect(bobFeed.data.feed[4].likeCount).toEqual(3)
+    expect(bobFeed.data.feed[3].likeCount).toEqual(2)
+    expect(bobFeed.data.feed[4]?.myState?.like).toEqual(
       bobLikes[alicePosts[1].toString()].toString(),
     )
     expect(bobFeed.data.feed[6]?.myState?.like).toBeUndefined()
@@ -445,13 +449,15 @@ describe('pds views', () => {
 
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
-      posts.alice[1],
-      posts.dan[1],
+      posts.alice[1], // Repost
+      posts.dan[1], // Repost
       replies.alice[0],
       replies.carol[0],
       replies.bob[0],
       posts.alice[2],
       posts.bob[1],
+      posts.alice[1], // Original post
+      posts.dan[1], // Original post
       posts.dan[0],
       posts.carol[0],
       posts.bob[0],
@@ -490,9 +496,9 @@ describe('pds views', () => {
     )
     /** @ts-ignore TODO */
     expect(aliceFeed.data.feed.map((item) => item.record.text)).toEqual([
-      posts.alice[1],
       replies.alice[0],
       posts.alice[2],
+      posts.alice[1],
       posts.alice[0],
     ])
 
@@ -505,7 +511,7 @@ describe('pds views', () => {
     )
     /** @ts-ignore TODO */
     expect(aliceFeed2.data.feed.map((item) => item.record.text)).toEqual([
-      replies.alice[0],
+      posts.alice[2],
     ])
 
     const carolFeed = await client.todo.social.getAuthorFeed(


### PR DESCRIPTION
There are a few fixes in here to home and author feeds:
 - A post and its repost are now distinguished from each other, and can appear together in the same feed.  This was fixed by adjusting the `groupBy()` clause.  This also repaired a flaky test, where `repostedBy` was sometimes not appearing when it should have.
 - Reposts are are ordered in the feed based on their indexed time, rather than that of their post.  The FeedItem `cursor` values are updated to reflect this.
 - Users' own posts (but not reposts) now appear in their feed. Resolves #201
