### PR TITLE
Plc tests & cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
       "**/ipld-hashmap",
       "**/ipld-hashmap/**",
       "**/sqlite3",
-      "**/sqlite3/**"
+      "**/sqlite3/**",
+      "**/better-sqlite3",
+      "**/better-sqlite3/**"
     ]
   }
 }

--- a/packages/did-resolver/package.json
+++ b/packages/did-resolver/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "jest",
+    "test:log": "cat test.log | pino-pretty",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/did-resolver/test.env
+++ b/packages/did-resolver/test.env
@@ -1,0 +1,2 @@
+LOG_ENABLED=true
+LOG_DESTINATION=test.log

--- a/packages/did-resolver/tests/resolver.test.ts
+++ b/packages/did-resolver/tests/resolver.test.ts
@@ -24,7 +24,8 @@ describe('resolver', () => {
       webServer._httpServer?.on('error', reject)
     })
 
-    const plcDB = await DidPlcDb.memory()
+    const plcDB = DidPlcDb.memory()
+    await plcDB.createTables()
     const plcPort = await getPort()
     const plcServer = await runPlcServer(plcDB, plcPort)
 
@@ -53,7 +54,7 @@ describe('resolver', () => {
     const signingKey = await EcdsaKeypair.create()
     const recoveryKey = await EcdsaKeypair.create()
     const username = 'alice.test'
-    const pds = 'service.test'
+    const pds = 'https://service.test'
     const client = new PlcClient(plcUrl)
     plcDid = await client.createDid(
       signingKey,

--- a/packages/plc/build.js
+++ b/packages/plc/build.js
@@ -13,6 +13,8 @@ require('esbuild')
     platform: 'node',
     assetNames: 'src/static',
     external: [
+      './node_modules/better-sqlite3/*',
+      '../../node_modules/better-sqlite3/*',
       './node_modules/sqlite3/*',
       '../../node_modules/sqlite3/*',
       '../../node_modules/level/*',

--- a/packages/plc/package.json
+++ b/packages/plc/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node dist/bin.js",
     "test": "jest",
+    "test:log": "cat test.log | pino-pretty",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
     "lint": "eslint . --ext .ts,.tsx",
@@ -16,6 +17,7 @@
     "low": "node dist/scripts/low_pid.js"
   },
   "dependencies": {
+    "@adxp/common": "*",
     "@adxp/crypto": "*",
     "@ipld/dag-cbor": "^7.0.3",
     "async-mutex": "^0.4.0",
@@ -26,6 +28,8 @@
     "express": "^4.17.2",
     "express-async-errors": "^3.1.1",
     "kysely": "^0.22.0",
+    "pino": "^8.6.1",
+    "pino-http": "^8.2.1",
     "uint8arrays": "3.0.0",
     "zod": "^3.14.2"
   },

--- a/packages/plc/package.json
+++ b/packages/plc/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "node dist/bin.js",
-    "test": "jest",
+    "test": "jest tests/server.test.ts",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/plc/package.json
+++ b/packages/plc/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "node dist/bin.js",
-    "test": "jest tests/server.test.ts",
+    "test": "jest",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/plc/src/lib/document.ts
+++ b/packages/plc/src/lib/document.ts
@@ -19,6 +19,15 @@ export const assureValidNextOp = async (
     await assureValidCreationOp(did, proposed)
     return { nullified: [], prev: null }
   }
+
+  // ensure we support the proposed key type
+  if (
+    check.is(proposed, t.def.rotateSigningKeyOp) ||
+    check.is(proposed, t.def.rotateRecoveryKeyOp)
+  ) {
+    await crypto.parseDidKey(proposed.key)
+  }
+
   const proposedPrev = proposed.prev ? CID.parse(proposed.prev) : undefined
   if (!proposedPrev) {
     throw new ServerError(400, `Invalid prev on operation: ${proposed.prev}`)

--- a/packages/plc/src/lib/document.ts
+++ b/packages/plc/src/lib/document.ts
@@ -174,7 +174,7 @@ export const formatDidDoc = (data: t.DocumentData): t.DidDocument => {
   return {
     '@context': context,
     id: data.did,
-    alsoKnownAs: [`https://${data.username}`],
+    alsoKnownAs: [ensureHttpPrefix(data.username)],
     verificationMethod: [
       {
         id: `#signingKey`,
@@ -196,7 +196,7 @@ export const formatDidDoc = (data: t.DocumentData): t.DidDocument => {
       {
         id: `#atpPds`,
         type: 'AtpPersonalDataServer',
-        serviceEndpoint: data.atpPds,
+        serviceEndpoint: ensureHttpPrefix(data.atpPds),
       },
     ],
   }
@@ -225,4 +225,11 @@ const formatKeyAndContext = (key: string): KeyAndContext => {
     }
   }
   throw new ServerError(400, `Unsupported key type: ${jwtAlg}`)
+}
+
+export const ensureHttpPrefix = (str: string): string => {
+  if (str.startsWith('http://') || str.startsWith('https://')) {
+    return str
+  }
+  return `https://${str}`
 }

--- a/packages/plc/src/lib/document.ts
+++ b/packages/plc/src/lib/document.ts
@@ -101,7 +101,6 @@ export const validateOperationLog = async (
   let prev = await cidForData(first)
 
   for (const op of rest) {
-    // @TODO should signing key be able to rotate reocvery key?? & should reocvery key be able to change username/service
     if (!op.prev || !CID.parse(op.prev).equals(prev)) {
       throw new ServerError(400, 'Operations not correctly ordered')
     }

--- a/packages/plc/src/lib/operations.ts
+++ b/packages/plc/src/lib/operations.ts
@@ -27,7 +27,7 @@ export const create = async (
   recoveryKey: string,
   username: string,
   service: string,
-): Promise<t.Operation> => {
+): Promise<t.CreateOp> => {
   const op: t.UnsignedCreateOp = {
     type: 'create',
     signingKey: signingKey.did(),
@@ -36,7 +36,8 @@ export const create = async (
     service,
     prev: null,
   }
-  return signOperation(op, signingKey)
+  const signed = await signOperation(op, signingKey)
+  return signed as t.CreateOp
 }
 
 export const rotateSigningKey = async (

--- a/packages/plc/src/server/db.ts
+++ b/packages/plc/src/server/db.ts
@@ -124,7 +124,7 @@ export class Database {
 
   async opsForDid(did: string): Promise<t.Operation[]> {
     const ops = await this._opsForDid(did)
-    return ops.filter((op) => !op.nullified).map((op) => op.operation)
+    return ops.map((op) => op.operation)
   }
 
   async _opsForDid(did: string): Promise<t.IndexedOperation[]> {
@@ -132,6 +132,7 @@ export class Database {
       .selectFrom('operations')
       .selectAll()
       .where('did', '=', did)
+      .where('nullified', '=', 0)
       .orderBy('createdAt', 'asc')
       .execute()
 

--- a/packages/plc/src/server/error.ts
+++ b/packages/plc/src/server/error.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
+import * as locals from './locals'
 
 export const handler = (
   err: Error,
@@ -6,13 +7,14 @@ export const handler = (
   res: Response,
   _next: NextFunction,
 ) => {
+  const { logger } = locals.get(res)
   let status
   if (ServerError.is(err)) {
     status = err.status
-    console.log('Info: ', err.message)
+    logger.info(err, 'handled server error')
   } else {
     status = 500
-    console.log('Error: ', err.message)
+    logger.error(err, 'unexpected internal server error')
   }
   res.status(status).send(err.message)
 }
@@ -25,7 +27,6 @@ export class ServerError extends Error {
   }
 
   static is(obj: unknown): obj is ServerError {
-    // @TODO would be nice to pull some of this out into an _actual_ `common` package
     return (
       !!obj &&
       typeof obj === 'object' &&

--- a/packages/plc/src/server/index.ts
+++ b/packages/plc/src/server/index.ts
@@ -11,6 +11,7 @@ import { Database } from './db'
 import * as error from './error'
 import router from './routes'
 import { Locals } from './locals'
+import { loggerMiddleware } from './logger'
 
 export * from './db'
 
@@ -19,9 +20,15 @@ export const server = (db: Database, port: number): http.Server => {
   app.use(express.json())
   app.use(cors())
 
-  app.use((_req, res, next) => {
-    const locals: Locals = { db }
-    Object.assign(res.locals, locals)
+  app.use(loggerMiddleware)
+
+  app.use((req, res, next) => {
+    const locals: Locals = {
+      // @ts-ignore
+      logger: req.log,
+      db,
+    }
+    res.locals = locals
     next()
   })
 

--- a/packages/plc/src/server/locals.ts
+++ b/packages/plc/src/server/locals.ts
@@ -1,16 +1,22 @@
 import { Response } from 'express'
+import pino from 'pino'
 import { Database } from './db'
 import { ServerError } from './error'
 
 export interface Locals {
+  logger: pino.Logger
   db: Database
 }
 
 export const get = (res: Response): Locals => {
+  if (!res.locals.logger) {
+    throw new ServerError(500, 'Could not find attached logger')
+  }
   if (!res.locals.db) {
     throw new ServerError(500, 'Could not connect to database')
   }
   return {
+    logger: res.locals.logger,
     db: res.locals.db,
   }
 }

--- a/packages/plc/src/server/logger.ts
+++ b/packages/plc/src/server/logger.ts
@@ -1,0 +1,8 @@
+import pinoHttp from 'pino-http'
+import { subsystemLogger } from '@adxp/common'
+
+export const logger = subsystemLogger('plc')
+
+export const loggerMiddleware = pinoHttp({
+  logger,
+})

--- a/packages/plc/test.env
+++ b/packages/plc/test.env
@@ -1,0 +1,2 @@
+LOG_ENABLED=false
+LOG_DESTINATION=test.log

--- a/packages/plc/tests/document.test.ts
+++ b/packages/plc/tests/document.test.ts
@@ -32,7 +32,7 @@ describe('plc DID document', () => {
     const isValid = check.is(createOp, t.def.createOp)
     expect(isValid).toBeTruthy()
     ops.push(createOp)
-    did = await operations.didForCreateOp(createOp as any)
+    did = await operations.didForCreateOp(createOp)
   })
 
   it('parses an operation log with no updates', async () => {

--- a/packages/plc/tests/document.test.ts
+++ b/packages/plc/tests/document.test.ts
@@ -216,7 +216,7 @@ describe('plc DID document', () => {
   })
 
   it('requires that the log start with a create operation', async () => {
-    const [_first, ...rest] = ops
+    const rest = ops.slice(1)
     expect(document.validateOperationLog(did, rest)).rejects.toThrow()
   })
 
@@ -261,5 +261,28 @@ describe('plc DID document', () => {
     expect(doc.service[0].id).toEqual('#atpPds')
     expect(doc.service[0].type).toEqual('AtpPersonalDataServer')
     expect(doc.service[0].serviceEndpoint).toEqual(atpPds)
+  })
+
+  it('formats a valid DID document regardless of leading https://', async () => {
+    username = 'https://alice.example.com'
+    const prev = await cidForData(ops[ops.length - 1])
+    const op1 = await operations.updateUsername(
+      username,
+      prev.toString(),
+      signingKey,
+    )
+    atpPds = 'example.com'
+    const prev2 = await cidForData(op1)
+    const op2 = await operations.updateAtpPds(
+      atpPds,
+      prev2.toString(),
+      signingKey,
+    )
+    ops.push(op1)
+    ops.push(op2)
+    const data = await document.validateOperationLog(did, ops)
+    const doc = await document.formatDidDoc(data)
+    expect(doc.alsoKnownAs).toEqual([username])
+    expect(doc.service[0].serviceEndpoint).toEqual(`https://${atpPds}`)
   })
 })

--- a/packages/plc/tests/server.test.ts
+++ b/packages/plc/tests/server.test.ts
@@ -4,6 +4,7 @@ import * as document from '../src/lib/document'
 import getPort from 'get-port'
 import * as util from './util'
 import { cidForData } from '@adxp/common'
+import { AxiosError } from 'axios'
 
 const USE_TEST_SERVER = true
 
@@ -80,6 +81,15 @@ describe('PLC server', () => {
     expect(doc.recoveryKey).toEqual(recoveryKey.did())
     expect(doc.username).toEqual(username)
     expect(doc.atpPds).toEqual(atpPds)
+  })
+
+  it('does not allow key types that we do not support', async () => {
+    // an ed25519 key which we don't yet support
+    const newSigningKey =
+      'did:key:z6MkjwbBXZnFqL8su24wGL2Fdjti6GSLv9SWdYGswfazUPm9'
+
+    const promise = client.rotateSigningKey(did, newSigningKey, signingKey)
+    await expect(promise).rejects.toThrow(AxiosError)
   })
 
   it('retrieves the operation log', async () => {

--- a/packages/server/tests/_util.ts
+++ b/packages/server/tests/_util.ts
@@ -32,7 +32,8 @@ export const runTestServer = async (
   // run plc server
   const plcPort = await getPort()
   const plcUrl = `http://localhost:${plcPort}`
-  const plcDb = await plc.Database.memory()
+  const plcDb = plc.Database.memory()
+  await plcDb.createTables()
   const plcServer = plc.server(plcDb, plcPort)
 
   // setup server did


### PR DESCRIPTION
Takes care of the tests from https://github.com/bluesky-social/adx/issues/211
- ensuring a valid did:key on key rotate ops (had to implement)
- a test around race conditions (& a bug that i sussed out on how we were returning ops)
- handling username/pds with or without a protocol handler (had to implement)

Adds logging with pino

Fixes some build issues around switching to keysely
- nohoist better-sqlite3 & mark it external in build script (I had to wipe out my node_modules & reinstall for this to work, you may have to do the same)
- fix up a couple of small things in tests for server/did-resolver to bring them up to date (mainly creating tables)

resolves https://github.com/bluesky-social/adx/issues/221