### PR TITLE
Fix PLC server usage in dev-env

### DIFF
--- a/packages/dev-env/build.js
+++ b/packages/dev-env/build.js
@@ -13,6 +13,7 @@ require('esbuild')
       '../plc/node_modules/@mapbox/node-pre-gyp/*',
       '../server/node_modules/sqlite3/*',
       '../../node_modules/classic-level/*',
+      '../../node_modules/better-sqlite3/*',
     ],
     plugins: [
       copy({

--- a/packages/dev-env/src/index.ts
+++ b/packages/dev-env/src/index.ts
@@ -88,7 +88,7 @@ export class DevEnvServer {
         break
       }
       case ServerType.DidPlaceholder: {
-        const db = await plc.Database.memory()
+        const db = await plc.Database.memory().createTables()
         this.inst = await onServerReady(plc.server(db, this.port))
         break
       }

--- a/packages/plc/src/server/db.ts
+++ b/packages/plc/src/server/db.ts
@@ -38,7 +38,7 @@ export class Database {
     await this.db.destroy()
   }
 
-  async createTables(): Promise<void> {
+  async createTables(): Promise<this> {
     await this.db.schema
       .createTable('operations')
       .addColumn('did', 'varchar', (col) => col.notNull())
@@ -48,6 +48,7 @@ export class Database {
       .addColumn('createdAt', 'varchar', (col) => col.notNull())
       .addPrimaryKeyConstraint('primary_key', ['did', 'cid'])
       .execute()
+    return this
   }
 
   async dropTables(): Promise<void> {

--- a/packages/server/tests/_util.ts
+++ b/packages/server/tests/_util.ts
@@ -33,8 +33,7 @@ export const runTestServer = async (
   // run plc server
   const plcPort = await getPort()
   const plcUrl = `http://localhost:${plcPort}`
-  const plcDb = plc.Database.memory()
-  await plcDb.createTables()
+  const plcDb = await plc.Database.memory().createTables()
   const plcServer = plc.server(plcDb, plcPort)
 
   // setup server did


### PR DESCRIPTION
The dev-env wasn't working as of the recent introduction of better-sqlite3.  Included here are the fixes!
 - Create the PLC tables when bootstrapping the PLC server in dev-env.
 - Ensure better-sqlite3 bindings are external to the dev-env build.