### PR TITLE
Postbuild typecheck

### DIFF
--- a/packages/dev-env/package.json
+++ b/packages/dev-env/package.json
@@ -4,6 +4,7 @@
   "main": "dist/cli.js",
   "scripts": {
     "build": "node ./build.js",
+    "postbuild" : "tsc --build tsconfig.build.json",
     "start": "node dist/cli.js",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",

--- a/packages/dev-env/tsconfig.build.json
+++ b/packages/dev-env/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/atproto.com/* ../../lexicons/bsky.app/*",
     "build": "node ./build.js",
-    "postbuild" : "tsc --build tsconfig.build.json",
+    "postbuild": "tsc --build tsconfig.build.json",
     "start": "node dist/bin.js",
     "test": "jest",
     "test:pg": "../pg/with-test-db.sh jest",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "codegen": "lex gen-server ./src/lexicon ../../lexicons/atproto.com/* ../../lexicons/bsky.app/*",
     "build": "node ./build.js",
+    "postbuild" : "tsc --build tsconfig.build.json",
     "start": "node dist/bin.js",
     "test": "jest",
     "test:pg": "../pg/with-test-db.sh jest",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+}


### PR DESCRIPTION
Esbuild doesn't do typechecks which is preventing us from catching some build issues

Add a postbuild script to server & dev-env that builds types as well.