### PR TITLE
Finalize lexicon reference behaviors, adding lex: URI references

### DIFF
--- a/lexicons/bsky.app/badge.json
+++ b/lexicons/bsky.app/badge.json
@@ -9,46 +9,46 @@
     "properties": {
       "assertion": {
         "oneOf": [
-          {"$ref": "#/$defs/inviteAssertion"},
-          {"$ref": "#/$defs/employeeAssertion"},
-          {"$ref": "#/$defs/tagAssertion"},
-          {"$ref": "#/$defs/unknownAssertion"}
+          {"$ref": "#/defs/inviteAssertion"},
+          {"$ref": "#/defs/employeeAssertion"},
+          {"$ref": "#/defs/tagAssertion"},
+          {"$ref": "#/defs/unknownAssertion"}
         ]
       },
       "subject": { "type": "string" },
       "createdAt": {"type": "string", "format": "date-time"}
+    }
+  },
+  "defs": {
+    "inviteAssertion": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {"const": "invite"}
+      }
     },
-    "$defs": {
-      "inviteAssertion": {
-        "type": "object",
-        "required": ["type"],
-        "properties": {
-          "type": {"const": "invite"}
-        }
-      },
-      "employeeAssertion": {
-        "type": "object",
-        "required": ["type"],
-        "properties": {
-          "type": {"const": "employee"}
-        }
-      },
-      "tagAssertion": {
-        "type": "object",
-        "required": ["type", "tag"],
-        "properties": {
-          "type": {"const": "tag"},
-          "tag": {"type": "string", "maxLength": 64}
-        }
-      },
-      "unknownAssertion": {
-        "type": "object",
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "type": "string",
-            "not": {"enum": ["invite", "employee", "tag"]}
-          }
+    "employeeAssertion": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {"const": "employee"}
+      }
+    },
+    "tagAssertion": {
+      "type": "object",
+      "required": ["type", "tag"],
+      "properties": {
+        "type": {"const": "tag"},
+        "tag": {"type": "string", "maxLength": 64}
+      }
+    },
+    "unknownAssertion": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "not": {"enum": ["invite", "employee", "tag"]}
         }
       }
     }

--- a/lexicons/bsky.app/getAuthorFeed.json
+++ b/lexicons/bsky.app/getAuthorFeed.json
@@ -16,81 +16,81 @@
       "properties": {
         "feed": {
           "type": "array",
-          "items": {"$ref": "#/$defs/feedItem"}
+          "items": {"$ref": "#/defs/feedItem"}
         }
-      },
-      "$defs": {
-        "feedItem": {
-          "type": "object",
-          "required": ["cursor", "uri", "cid", "author", "record", "replyCount", "repostCount", "likeCount", "indexedAt"],
-          "properties": {
-            "cursor": {"type": "string"},
-            "uri": {"type": "string"},
-            "cid": {"type": "string"},
-            "author": {"$ref": "#/$defs/user"},
-            "repostedBy": {"$ref": "#/$defs/user"},
-            "record": {"type": "object"},
-            "embed": {
-              "oneOf": [
-                {"$ref": "#/$defs/recordEmbed"},
-                {"$ref": "#/$defs/externalEmbed"},
-                {"$ref": "#/$defs/unknownEmbed"}
-              ]
-            },
-            "replyCount": {"type": "number"},
-            "repostCount": {"type": "number"},
-            "likeCount": {"type": "number"},
-            "indexedAt": {"type": "string", "format": "date-time"},
-            "myState": {
-              "type": "object",
-              "properties": {
-                "repost": {"type": "string"},
-                "like": {"type": "string"}
-              }
-            }
-          }
+      }
+    }
+  },
+  "defs": {
+    "feedItem": {
+      "type": "object",
+      "required": ["cursor", "uri", "cid", "author", "record", "replyCount", "repostCount", "likeCount", "indexedAt"],
+      "properties": {
+        "cursor": {"type": "string"},
+        "uri": {"type": "string"},
+        "cid": {"type": "string"},
+        "author": {"$ref": "#/defs/user"},
+        "repostedBy": {"$ref": "#/defs/user"},
+        "record": {"type": "object"},
+        "embed": {
+          "oneOf": [
+            {"$ref": "#/defs/recordEmbed"},
+            {"$ref": "#/defs/externalEmbed"},
+            {"$ref": "#/defs/unknownEmbed"}
+          ]
         },
-        "user": {
+        "replyCount": {"type": "number"},
+        "repostCount": {"type": "number"},
+        "likeCount": {"type": "number"},
+        "indexedAt": {"type": "string", "format": "date-time"},
+        "myState": {
           "type": "object",
-          "required": ["did", "name"],
           "properties": {
-            "did": {"type": "string"},
-            "name": {"type": "string"},
-            "displayName": {
-              "type": "string",
-              "maxLength": 64
-            }
+            "repost": {"type": "string"},
+            "like": {"type": "string"}
           }
-        },
-        "recordEmbed": {
-          "type": "object",
-          "required": ["type", "author", "record"],
-          "properties": {
-            "type": {"const": "record"},
-            "author": {"$ref": "#/$defs/user"},
-            "record": {"type": "object"}
-          }
-        },
-        "externalEmbed": {
-          "type": "object",
-          "required": ["type", "uri", "title", "description", "imageUri"],
-          "properties": {
-            "type": {"const": "external"},
-            "uri": {"type": "string"},
-            "title": {"type": "string"},
-            "description": {"type": "string"},
-            "imageUri": {"type": "string"}
-          }
-        },
-        "unknownEmbed": {
-          "type": "object",
-          "required": ["type"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "not": {"enum": ["record", "external"]}
-            }
-          }
+        }
+      }
+    },
+    "user": {
+      "type": "object",
+      "required": ["did", "name"],
+      "properties": {
+        "did": {"type": "string"},
+        "name": {"type": "string"},
+        "displayName": {
+          "type": "string",
+          "maxLength": 64
+        }
+      }
+    },
+    "recordEmbed": {
+      "type": "object",
+      "required": ["type", "author", "record"],
+      "properties": {
+        "type": {"const": "record"},
+        "author": {"$ref": "#/defs/user"},
+        "record": {"type": "object"}
+      }
+    },
+    "externalEmbed": {
+      "type": "object",
+      "required": ["type", "uri", "title", "description", "imageUri"],
+      "properties": {
+        "type": {"const": "external"},
+        "uri": {"type": "string"},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "imageUri": {"type": "string"}
+      }
+    },
+    "unknownEmbed": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "not": {"enum": ["record", "external"]}
         }
       }
     }

--- a/lexicons/bsky.app/getHomeFeed.json
+++ b/lexicons/bsky.app/getHomeFeed.json
@@ -16,81 +16,81 @@
       "properties": {
         "feed": {
           "type": "array",
-          "items": {"$ref": "#/$defs/feedItem"}
+          "items": {"$ref": "#/defs/feedItem"}
         }
-      },
-      "$defs": {
-        "feedItem": {
-          "type": "object",
-          "required": ["cursor", "uri", "cid", "author", "record", "replyCount", "repostCount", "likeCount", "indexedAt"],
-          "properties": {
-            "cursor": {"type": "string"},
-            "uri": {"type": "string"},
-            "cid": {"type": "string"},
-            "author": {"$ref": "#/$defs/user"},
-            "repostedBy": {"$ref": "#/$defs/user"},
-            "record": {"type": "object"},
-            "embed": {
-              "oneOf": [
-                {"$ref": "#/$defs/recordEmbed"},
-                {"$ref": "#/$defs/externalEmbed"},
-                {"$ref": "#/$defs/unknownEmbed"}
-              ]
-            },
-            "replyCount": {"type": "number"},
-            "repostCount": {"type": "number"},
-            "likeCount": {"type": "number"},
-            "indexedAt": {"type": "string", "format": "date-time"},
-            "myState": {
-              "type": "object",
-              "properties": {
-                "repost": {"type": "string"},
-                "like": {"type": "string"}
-              }
-            }
-          }
+      }
+    }
+  },
+  "defs": {
+    "feedItem": {
+      "type": "object",
+      "required": ["cursor", "uri", "cid", "author", "record", "replyCount", "repostCount", "likeCount", "indexedAt"],
+      "properties": {
+        "cursor": {"type": "string"},
+        "uri": {"type": "string"},
+        "cid": {"type": "string"},
+        "author": {"$ref": "#/defs/user"},
+        "repostedBy": {"$ref": "#/defs/user"},
+        "record": {"type": "object"},
+        "embed": {
+          "oneOf": [
+            {"$ref": "#/defs/recordEmbed"},
+            {"$ref": "#/defs/externalEmbed"},
+            {"$ref": "#/defs/unknownEmbed"}
+          ]
         },
-        "user": {
+        "replyCount": {"type": "number"},
+        "repostCount": {"type": "number"},
+        "likeCount": {"type": "number"},
+        "indexedAt": {"type": "string", "format": "date-time"},
+        "myState": {
           "type": "object",
-          "required": ["did", "name"],
           "properties": {
-            "did": {"type": "string"},
-            "name": {"type": "string"},
-            "displayName": {
-              "type": "string",
-              "maxLength": 64
-            }
+            "repost": {"type": "string"},
+            "like": {"type": "string"}
           }
-        },
-        "recordEmbed": {
-          "type": "object",
-          "required": ["type", "author", "record"],
-          "properties": {
-            "type": {"const": "record"},
-            "author": {"$ref": "#/$defs/user"},
-            "record": {"type": "object"}
-          }
-        },
-        "externalEmbed": {
-          "type": "object",
-          "required": ["type", "uri", "title", "description", "imageUri"],
-          "properties": {
-            "type": {"const": "external"},
-            "uri": {"type": "string"},
-            "title": {"type": "string"},
-            "description": {"type": "string"},
-            "imageUri": {"type": "string"}
-          }
-        },
-        "unknownEmbed": {
-          "type": "object",
-          "required": ["type"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "not": {"enum": ["record", "external"]}
-            }
-          }
+        }
+      }
+    },
+    "user": {
+      "type": "object",
+      "required": ["did", "name"],
+      "properties": {
+        "did": {"type": "string"},
+        "name": {"type": "string"},
+        "displayName": {
+          "type": "string",
+          "maxLength": 64
+        }
+      }
+    },
+    "recordEmbed": {
+      "type": "object",
+      "required": ["type", "author", "record"],
+      "properties": {
+        "type": {"const": "record"},
+        "author": {"$ref": "#/defs/user"},
+        "record": {"type": "object"}
+      }
+    },
+    "externalEmbed": {
+      "type": "object",
+      "required": ["type", "uri", "title", "description", "imageUri"],
+      "properties": {
+        "type": {"const": "external"},
+        "uri": {"type": "string"},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "imageUri": {"type": "string"}
+      }
+    },
+    "unknownEmbed": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "not": {"enum": ["record", "external"]}
         }
       }
     }

--- a/lexicons/bsky.app/getNotifications.json
+++ b/lexicons/bsky.app/getNotifications.json
@@ -14,38 +14,38 @@
       "properties": {
         "notifications": {
           "type": "array",
-          "items": {"$ref": "#/$defs/notification"}
+          "items": {"$ref": "#/defs/notification"}
         }
-      },
-      "$defs": {
-        "notification": {
+      }
+    }
+  },
+  "defs": {
+    "notification": {
+      "type": "object",
+      "required": ["uri", "cid", "author", "reason", "record", "isRead", "indexedAt"],
+      "properties": {
+        "uri": {"type": "string", "format": "uri"},
+        "cid": {"type": "string" },
+        "author": {
           "type": "object",
-          "required": ["uri", "cid", "author", "reason", "record", "isRead", "indexedAt"],
+          "required": ["did", "name"],
           "properties": {
-            "uri": {"type": "string", "format": "uri"},
-            "cid": {"type": "string" },
-            "author": {
-              "type": "object",
-              "required": ["did", "name"],
-              "properties": {
-                "did": {"type": "string"},
-                "name": {"type": "string"},
-                "displayName": {
-                  "type": "string",
-                  "maxLength": 64
-                }
-              }
-            },
-            "reason": {
+            "did": {"type": "string"},
+            "name": {"type": "string"},
+            "displayName": {
               "type": "string",
-              "$comment": "Expected values are 'like', 'repost', 'follow', 'badge', 'mention' and 'reply'."
-            },
-            "reasonSubject": {"type": "string"},
-            "record": {"type": "object"},
-            "isRead": {"type": "boolean"},
-            "indexedAt": {"type": "string", "format": "date-time"}
+              "maxLength": 64
+            }
           }
-        }
+        },
+        "reason": {
+          "type": "string",
+          "$comment": "Expected values are 'like', 'repost', 'follow', 'badge', 'mention' and 'reply'."
+        },
+        "reasonSubject": {"type": "string"},
+        "record": {"type": "object"},
+        "isRead": {"type": "boolean"},
+        "indexedAt": {"type": "string", "format": "date-time"}
       }
     }
   }

--- a/lexicons/bsky.app/getPostThread.json
+++ b/lexicons/bsky.app/getPostThread.json
@@ -12,83 +12,83 @@
       "type": "object",
       "required": ["thread"],
       "properties": {
-        "thread": {"$ref": "#/$defs/post"}
-      },
-      "$defs": {
-        "post": {
-          "type": "object",
-          "required": ["uri", "cid", "author", "record", "replyCount", "likeCount", "repostCount", "indexedAt"],
-          "properties": {
-            "uri": {"type": "string"},
-            "cid": {"type": "string"},
-            "author": {"$ref": "#/$defs/user"},
-            "record": {"type": "object"},
-            "embed": {
-              "oneOf": [
-                {"$ref": "#/$defs/recordEmbed"},
-                {"$ref": "#/$defs/externalEmbed"},
-                {"$ref": "#/$defs/unknownEmbed"}
-              ]
-            },
-            "parent": {"$ref": "#/$defs/post"},
-            "replyCount": {"type": "number"},
-            "replies": {
-              "type": "array",
-              "items": {"$ref": "#/$defs/post"}
-            },
-            "likeCount": {"type": "number"},
-            "repostCount": {"type": "number"},
-            "indexedAt": {"type": "string", "format": "date-time"},
-            "myState": {
-              "type": "object",
-              "properties": {
-                "repost": {"type": "string"},
-                "like": {"type": "string"}
-              }
-            }
-          }
+        "thread": {"$ref": "#/defs/post"}
+      }
+    }
+  },
+  "defs": {
+    "post": {
+      "type": "object",
+      "required": ["uri", "cid", "author", "record", "replyCount", "likeCount", "repostCount", "indexedAt"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"},
+        "author": {"$ref": "#/defs/user"},
+        "record": {"type": "object"},
+        "embed": {
+          "oneOf": [
+            {"$ref": "#/defs/recordEmbed"},
+            {"$ref": "#/defs/externalEmbed"},
+            {"$ref": "#/defs/unknownEmbed"}
+          ]
         },
-        "user": {
-          "type": "object",
-          "required": ["did", "name"],
-          "properties": {
-            "did": {"type": "string"},
-            "name": {"type": "string"},
-            "displayName": {
-              "type": "string",
-              "maxLength": 64
-            }
-          }
+        "parent": {"$ref": "#/defs/post"},
+        "replyCount": {"type": "number"},
+        "replies": {
+          "type": "array",
+          "items": {"$ref": "#/defs/post"}
         },
-        "recordEmbed": {
+        "likeCount": {"type": "number"},
+        "repostCount": {"type": "number"},
+        "indexedAt": {"type": "string", "format": "date-time"},
+        "myState": {
           "type": "object",
-          "required": ["type", "author", "record"],
           "properties": {
-            "type": {"const": "record"},
-            "author": {"$ref": "#/$defs/user"},
-            "record": {"type": "object"}
+            "repost": {"type": "string"},
+            "like": {"type": "string"}
           }
-        },
-        "externalEmbed": {
-          "type": "object",
-          "required": ["type", "uri", "title", "description", "imageUri"],
-          "properties": {
-            "type": {"const": "external"},
-            "uri": {"type": "string"},
-            "title": {"type": "string"},
-            "description": {"type": "string"},
-            "imageUri": {"type": "string"}
-          }
-        },
-        "unknownEmbed": {
-          "type": "object",
-          "required": ["type"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "not": {"enum": ["record", "external"]}
-            }
-          }
+        }
+      }
+    },
+    "user": {
+      "type": "object",
+      "required": ["did", "name"],
+      "properties": {
+        "did": {"type": "string"},
+        "name": {"type": "string"},
+        "displayName": {
+          "type": "string",
+          "maxLength": 64
+        }
+      }
+    },
+    "recordEmbed": {
+      "type": "object",
+      "required": ["type", "author", "record"],
+      "properties": {
+        "type": {"const": "record"},
+        "author": {"$ref": "#/defs/user"},
+        "record": {"type": "object"}
+      }
+    },
+    "externalEmbed": {
+      "type": "object",
+      "required": ["type", "uri", "title", "description", "imageUri"],
+      "properties": {
+        "type": {"const": "external"},
+        "uri": {"type": "string"},
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "imageUri": {"type": "string"}
+      }
+    },
+    "unknownEmbed": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "not": {"enum": ["record", "external"]}
         }
       }
     }

--- a/lexicons/bsky.app/getProfile.json
+++ b/lexicons/bsky.app/getProfile.json
@@ -24,44 +24,44 @@
         "followersCount": {"type": "number"},
         "followsCount": {"type": "number"},
         "postsCount": {"type": "number"},
-        "badges": {"type": "array", "items": {"$ref":"#/$defs/badge"}},
+        "badges": {"type": "array", "items": {"$ref":"#/defs/badge"}},
         "myState": {
           "type": "object",
           "properties": {
             "follow": {"type": "string"}
           }
         }
-      },
-      "$defs": {
-        "badge": {
+      }
+    }
+  },
+  "defs": {
+    "badge": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"},
+        "error": {"type": "string"},
+        "issuer": {
           "type": "object",
-          "required": ["uri", "cid"],
+          "required": ["did", "name", "displayName"],
           "properties": {
-            "uri": {"type": "string"},
-            "cid": {"type": "string"},
-            "error": {"type": "string"},
-            "issuer": {
-              "type": "object",
-              "required": ["did", "name", "displayName"],
-              "properties": {
-                "did": {"type": "string"},
-                "name": {"type": "string"},
-                "displayName": {
-                  "type": "string",
-                  "maxLength": 64
-                }
-              }
-            },
-            "assertion": {
-              "type": "object",
-              "required": ["type"],
-              "properties": {
-                "type": {"type": "string"}
-              }
-            },
-            "createdAt": {"type": "string", "format": "date-time"}
+            "did": {"type": "string"},
+            "name": {"type": "string"},
+            "displayName": {
+              "type": "string",
+              "maxLength": 64
+            }
           }
-        }
+        },
+        "assertion": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {"type": "string"}
+          }
+        },
+        "createdAt": {"type": "string", "format": "date-time"}
       }
     }
   }

--- a/lexicons/bsky.app/like.json
+++ b/lexicons/bsky.app/like.json
@@ -6,17 +6,17 @@
     "type": "object",
     "required": ["subject", "createdAt"],
     "properties": {
-      "subject": {"$ref": "#/$defs/subject"},
+      "subject": {"$ref": "#/defs/subject"},
       "createdAt": {"type": "string", "format": "date-time"}
-    },
-    "$defs": {
-      "subject": {
-        "type": "object",
-        "required": ["uri", "cid"],
-        "properties": {
-          "uri": {"type": "string"},
-          "cid": {"type": "string"}
-        }
+    }
+  },
+  "defs": {
+    "subject": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"}
       }
     }
   }

--- a/lexicons/bsky.app/mediaEmbed.json
+++ b/lexicons/bsky.app/mediaEmbed.json
@@ -7,25 +7,25 @@
     "type": "object",
     "required": ["media"],
     "properties": {
-      "media": {"type": "array", "items": {"$ref": "#/$defs/mediaEmbed"}}
+      "media": {"type": "array", "items": {"$ref": "#/defs/mediaEmbed"}}
+    }
+  },
+  "defs": {
+    "mediaEmbed": {
+      "type": "object",
+      "required": ["original"],
+      "properties": {
+        "alt": {"type": "string"},
+        "thumb": {"$ref": "#/defs/mediaEmbedBlob"},
+        "original": {"$ref": "#/defs/mediaEmbedBlob"}
+      }
     },
-    "$defs": {
-      "mediaEmbed": {
-        "type": "object",
-        "required": ["original"],
-        "properties": {
-          "alt": {"type": "string"},
-          "thumb": {"$ref": "#/$defs/mediaEmbedBlob"},
-          "original": {"$ref": "#/$defs/mediaEmbedBlob"}
-        }
-      },
-      "mediaEmbedBlob": {
-        "type": "object",
-        "required": ["mimeType", "blobId"],
-        "properties": {
-          "mimeType": {"type": "string"},
-          "blobId": {"type": "string"}
-        }
+    "mediaEmbedBlob": {
+      "type": "object",
+      "required": ["mimeType", "blobId"],
+      "properties": {
+        "mimeType": {"type": "string"},
+        "blobId": {"type": "string"}
       }
     }
   }

--- a/lexicons/bsky.app/post.json
+++ b/lexicons/bsky.app/post.json
@@ -7,47 +7,47 @@
     "required": ["text", "createdAt"],
     "properties": {
       "text": {"type": "string", "maxLength": 256},
-      "entities": {"$ref": "#/$defs/entity"},
+      "entities": {"$ref": "#/defs/entity"},
       "reply": {
         "type": "object",
         "required": ["root", "parent"],
         "properties": {
-          "root": {"$ref": "#/$defs/postRef"},
-          "parent": {"$ref": "#/$defs/postRef"}
+          "root": {"$ref": "#/defs/postRef"},
+          "parent": {"$ref": "#/defs/postRef"}
         }
       },
       "createdAt": {"type": "string", "format": "date-time"}
-    },
-    "$defs": {
-      "postRef": {
-        "type": "object",
-        "required": ["uri", "cid"],
-        "properties": {
-          "uri": {"type": "string"},
-          "cid": {"type": "string"}
-        }
-      },
-      "entity": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "required": ["index", "type", "value"],
-          "properties": {
-            "index": {"$ref": "#/$defs/textSlice"},
-            "type": {
-              "type": "string",
-              "$comment": "Expected values are 'mention', 'hashtag', and 'link'."
-            },
-            "value": {"type": "string"}
-          }
-        }
-      },
-      "textSlice": {
-        "type": "array",
-        "items": [{"type": "number"}, {"type": "number"}],
-        "minItems": 2,
-        "maxItems": 2
+    }
+  },
+  "defs": {
+    "postRef": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"}
       }
+    },
+    "entity": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["index", "type", "value"],
+        "properties": {
+          "index": {"$ref": "#/defs/textSlice"},
+          "type": {
+            "type": "string",
+            "$comment": "Expected values are 'mention', 'hashtag', and 'link'."
+          },
+          "value": {"type": "string"}
+        }
+      }
+    },
+    "textSlice": {
+      "type": "array",
+      "items": [{"type": "number"}, {"type": "number"}],
+      "minItems": 2,
+      "maxItems": 2
     }
   }
 }

--- a/lexicons/bsky.app/profile.json
+++ b/lexicons/bsky.app/profile.json
@@ -14,16 +14,16 @@
         "type": "string",
         "maxLength": 256
       },
-      "badges": {"type": "array", "items": {"$ref": "#/$defs/badgeRef"}}
-    },
-    "$defs": {
-      "badgeRef": {
-        "type": "object",
-        "required": ["uri", "cid"],
-        "properties": {
-          "uri": {"type": "string"},
-          "cid": {"type": "string"}
-        }
+      "badges": {"type": "array", "items": {"$ref": "#/defs/badgeRef"}}
+    }
+  },
+  "defs": {
+    "badgeRef": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"}
       }
     }
   }

--- a/lexicons/bsky.app/repost.json
+++ b/lexicons/bsky.app/repost.json
@@ -6,17 +6,17 @@
     "type": "object",
     "required": ["subject", "createdAt"],
     "properties": {
-      "subject": {"$ref": "#/$defs/subject"},
+      "subject": {"$ref": "#/defs/subject"},
       "createdAt": {"type": "string", "format": "date-time"}
-    },
-    "$defs": {
-      "subject": {
-        "type": "object",
-        "required": ["uri", "cid"],
-        "properties": {
-          "uri": {"type": "string"},
-          "cid": {"type": "string"}
-        }
+    }
+  },
+  "defs": {
+    "subject": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": {"type": "string"},
+        "cid": {"type": "string"}
       }
     }
   }

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -29,6 +29,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -47,6 +48,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     errors: [
@@ -80,6 +82,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'number',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -92,6 +95,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -114,6 +118,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -132,6 +137,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -143,11 +149,15 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {},
     input: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -158,11 +168,15 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {},
     input: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -173,11 +187,15 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {},
     input: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -203,6 +221,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -225,6 +244,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -236,13 +256,13 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       validate: {
         type: 'boolean',
-        description: 'Validate the records?',
         default: true,
+        description: 'Validate the records?',
       },
     },
     input: {
@@ -306,11 +326,14 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
     output: {
       encoding: 'application/json',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -321,23 +344,26 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record collection.',
         required: true,
+        description: 'The NSID of the record collection.',
       },
       validate: {
         type: 'boolean',
-        description: 'Validate the record?',
         default: true,
+        description: 'Validate the record?',
       },
     },
     input: {
       encoding: 'application/json',
-      schema: {},
+      description: 'The record to create',
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: 'application/json',
@@ -352,6 +378,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -363,18 +390,18 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record collection.',
         required: true,
+        description: 'The NSID of the record collection.',
       },
       rkey: {
         type: 'string',
-        description: 'The key of the record.',
         required: true,
+        description: 'The key of the record.',
       },
     },
   },
@@ -387,8 +414,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       user: {
         type: 'string',
-        description: 'The username or DID of the repo.',
         required: true,
+        description: 'The username or DID of the repo.',
       },
     },
     output: {
@@ -416,6 +443,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'boolean',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -427,24 +455,24 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       user: {
         type: 'string',
-        description: 'The username or DID of the repo.',
         required: true,
+        description: 'The username or DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the collection.',
         required: true,
+        description: 'The NSID of the collection.',
       },
       rkey: {
         type: 'string',
-        description: 'The key of the record.',
         required: true,
+        description: 'The key of the record.',
       },
       cid: {
         type: 'string',
+        required: false,
         description:
           'The CID of the version of the record. If not specified, then return the most recent version.',
-        required: false,
       },
     },
     output: {
@@ -463,6 +491,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'object',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -474,19 +503,19 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       user: {
         type: 'string',
-        description: 'The username or DID of the repo.',
         required: true,
+        description: 'The username or DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record type.',
         required: true,
+        description: 'The NSID of the record type.',
       },
       limit: {
         type: 'number',
-        description: 'The number of records to return. TODO-max number?',
-        default: 50,
         minimum: 1,
+        default: 50,
+        description: 'The number of records to return. TODO-max number?',
       },
       before: {
         type: 'string',
@@ -527,6 +556,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -538,28 +568,30 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record type.',
         required: true,
+        description: 'The NSID of the record type.',
       },
       rkey: {
         type: 'string',
-        description: 'The TID of the record.',
         required: true,
+        description: 'The TID of the record.',
       },
       validate: {
         type: 'boolean',
-        description: 'Validate the record?',
         default: true,
+        description: 'Validate the record?',
       },
     },
     input: {
       encoding: 'application/json',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: 'application/json',
@@ -574,6 +606,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -593,6 +626,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -600,6 +634,7 @@ export const methodSchemas: MethodSchema[] = [
       schema: {
         type: 'object',
         properties: {},
+        $defs: {},
       },
     },
   },
@@ -622,6 +657,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -629,6 +665,7 @@ export const methodSchemas: MethodSchema[] = [
       schema: {
         type: 'object',
         properties: {},
+        $defs: {},
       },
     },
     errors: [
@@ -662,6 +699,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -673,8 +711,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       from: {
         type: 'string',
@@ -693,8 +731,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
     },
     output: {
@@ -707,6 +745,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -718,8 +757,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
     },
     input: {
@@ -753,12 +792,12 @@ export const methodSchemas: MethodSchema[] = [
           feed: {
             type: 'array',
             items: {
-              $ref: '#/$defs/feedItem',
+              $ref: '#/$defs/appBskyGetAuthorFeedFeedItem',
             },
           },
         },
         $defs: {
-          feedItem: {
+          appBskyGetAuthorFeedFeedItem: {
             type: 'object',
             required: [
               'cursor',
@@ -782,10 +821,10 @@ export const methodSchemas: MethodSchema[] = [
                 type: 'string',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetAuthorFeedUser',
               },
               repostedBy: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetAuthorFeedUser',
               },
               record: {
                 type: 'object',
@@ -793,13 +832,13 @@ export const methodSchemas: MethodSchema[] = [
               embed: {
                 oneOf: [
                   {
-                    $ref: '#/$defs/recordEmbed',
+                    $ref: '#/$defs/appBskyGetAuthorFeedRecordEmbed',
                   },
                   {
-                    $ref: '#/$defs/externalEmbed',
+                    $ref: '#/$defs/appBskyGetAuthorFeedExternalEmbed',
                   },
                   {
-                    $ref: '#/$defs/unknownEmbed',
+                    $ref: '#/$defs/appBskyGetAuthorFeedUnknownEmbed',
                   },
                 ],
               },
@@ -829,7 +868,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          user: {
+          appBskyGetAuthorFeedUser: {
             type: 'object',
             required: ['did', 'name'],
             properties: {
@@ -845,7 +884,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          recordEmbed: {
+          appBskyGetAuthorFeedRecordEmbed: {
             type: 'object',
             required: ['type', 'author', 'record'],
             properties: {
@@ -853,14 +892,14 @@ export const methodSchemas: MethodSchema[] = [
                 const: 'record',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetAuthorFeedUser',
               },
               record: {
                 type: 'object',
               },
             },
           },
-          externalEmbed: {
+          appBskyGetAuthorFeedExternalEmbed: {
             type: 'object',
             required: ['type', 'uri', 'title', 'description', 'imageUri'],
             properties: {
@@ -881,7 +920,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          unknownEmbed: {
+          appBskyGetAuthorFeedUnknownEmbed: {
             type: 'object',
             required: ['type'],
             properties: {
@@ -891,6 +930,143 @@ export const methodSchemas: MethodSchema[] = [
                   enum: ['record', 'external'],
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      feedItem: {
+        type: 'object',
+        required: [
+          'cursor',
+          'uri',
+          'cid',
+          'author',
+          'record',
+          'replyCount',
+          'repostCount',
+          'likeCount',
+          'indexedAt',
+        ],
+        properties: {
+          cursor: {
+            type: 'string',
+          },
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetAuthorFeedUser',
+          },
+          repostedBy: {
+            $ref: '#/$defs/appBskyGetAuthorFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+          embed: {
+            oneOf: [
+              {
+                $ref: '#/$defs/appBskyGetAuthorFeedRecordEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetAuthorFeedExternalEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetAuthorFeedUnknownEmbed',
+              },
+            ],
+          },
+          replyCount: {
+            type: 'number',
+          },
+          repostCount: {
+            type: 'number',
+          },
+          likeCount: {
+            type: 'number',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          myState: {
+            type: 'object',
+            properties: {
+              repost: {
+                type: 'string',
+              },
+              like: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        type: 'object',
+        required: ['did', 'name'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      recordEmbed: {
+        type: 'object',
+        required: ['type', 'author', 'record'],
+        properties: {
+          type: {
+            const: 'record',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetAuthorFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+        },
+      },
+      externalEmbed: {
+        type: 'object',
+        required: ['type', 'uri', 'title', 'description', 'imageUri'],
+        properties: {
+          type: {
+            const: 'external',
+          },
+          uri: {
+            type: 'string',
+          },
+          title: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          imageUri: {
+            type: 'string',
+          },
+        },
+      },
+      unknownEmbed: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['record', 'external'],
             },
           },
         },
@@ -923,12 +1099,12 @@ export const methodSchemas: MethodSchema[] = [
           feed: {
             type: 'array',
             items: {
-              $ref: '#/$defs/feedItem',
+              $ref: '#/$defs/appBskyGetHomeFeedFeedItem',
             },
           },
         },
         $defs: {
-          feedItem: {
+          appBskyGetHomeFeedFeedItem: {
             type: 'object',
             required: [
               'cursor',
@@ -952,10 +1128,10 @@ export const methodSchemas: MethodSchema[] = [
                 type: 'string',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetHomeFeedUser',
               },
               repostedBy: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetHomeFeedUser',
               },
               record: {
                 type: 'object',
@@ -963,13 +1139,13 @@ export const methodSchemas: MethodSchema[] = [
               embed: {
                 oneOf: [
                   {
-                    $ref: '#/$defs/recordEmbed',
+                    $ref: '#/$defs/appBskyGetHomeFeedRecordEmbed',
                   },
                   {
-                    $ref: '#/$defs/externalEmbed',
+                    $ref: '#/$defs/appBskyGetHomeFeedExternalEmbed',
                   },
                   {
-                    $ref: '#/$defs/unknownEmbed',
+                    $ref: '#/$defs/appBskyGetHomeFeedUnknownEmbed',
                   },
                 ],
               },
@@ -999,7 +1175,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          user: {
+          appBskyGetHomeFeedUser: {
             type: 'object',
             required: ['did', 'name'],
             properties: {
@@ -1015,7 +1191,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          recordEmbed: {
+          appBskyGetHomeFeedRecordEmbed: {
             type: 'object',
             required: ['type', 'author', 'record'],
             properties: {
@@ -1023,14 +1199,14 @@ export const methodSchemas: MethodSchema[] = [
                 const: 'record',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetHomeFeedUser',
               },
               record: {
                 type: 'object',
               },
             },
           },
-          externalEmbed: {
+          appBskyGetHomeFeedExternalEmbed: {
             type: 'object',
             required: ['type', 'uri', 'title', 'description', 'imageUri'],
             properties: {
@@ -1051,7 +1227,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          unknownEmbed: {
+          appBskyGetHomeFeedUnknownEmbed: {
             type: 'object',
             required: ['type'],
             properties: {
@@ -1061,6 +1237,143 @@ export const methodSchemas: MethodSchema[] = [
                   enum: ['record', 'external'],
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      feedItem: {
+        type: 'object',
+        required: [
+          'cursor',
+          'uri',
+          'cid',
+          'author',
+          'record',
+          'replyCount',
+          'repostCount',
+          'likeCount',
+          'indexedAt',
+        ],
+        properties: {
+          cursor: {
+            type: 'string',
+          },
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetHomeFeedUser',
+          },
+          repostedBy: {
+            $ref: '#/$defs/appBskyGetHomeFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+          embed: {
+            oneOf: [
+              {
+                $ref: '#/$defs/appBskyGetHomeFeedRecordEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetHomeFeedExternalEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetHomeFeedUnknownEmbed',
+              },
+            ],
+          },
+          replyCount: {
+            type: 'number',
+          },
+          repostCount: {
+            type: 'number',
+          },
+          likeCount: {
+            type: 'number',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          myState: {
+            type: 'object',
+            properties: {
+              repost: {
+                type: 'string',
+              },
+              like: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        type: 'object',
+        required: ['did', 'name'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      recordEmbed: {
+        type: 'object',
+        required: ['type', 'author', 'record'],
+        properties: {
+          type: {
+            const: 'record',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetHomeFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+        },
+      },
+      externalEmbed: {
+        type: 'object',
+        required: ['type', 'uri', 'title', 'description', 'imageUri'],
+        properties: {
+          type: {
+            const: 'external',
+          },
+          uri: {
+            type: 'string',
+          },
+          title: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          imageUri: {
+            type: 'string',
+          },
+        },
+      },
+      unknownEmbed: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['record', 'external'],
             },
           },
         },
@@ -1128,6 +1441,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1146,6 +1460,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'number',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1171,12 +1486,12 @@ export const methodSchemas: MethodSchema[] = [
           notifications: {
             type: 'array',
             items: {
-              $ref: '#/$defs/notification',
+              $ref: '#/$defs/appBskyGetNotificationsNotification',
             },
           },
         },
         $defs: {
-          notification: {
+          appBskyGetNotificationsNotification: {
             type: 'object',
             required: [
               'uri',
@@ -1234,6 +1549,63 @@ export const methodSchemas: MethodSchema[] = [
         },
       },
     },
+    defs: {
+      notification: {
+        type: 'object',
+        required: [
+          'uri',
+          'cid',
+          'author',
+          'reason',
+          'record',
+          'isRead',
+          'indexedAt',
+        ],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'uri',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            type: 'object',
+            required: ['did', 'name'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              name: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+          reason: {
+            type: 'string',
+            $comment:
+              "Expected values are 'like', 'repost', 'follow', 'badge', 'mention' and 'reply'.",
+          },
+          reasonSubject: {
+            type: 'string',
+          },
+          record: {
+            type: 'object',
+          },
+          isRead: {
+            type: 'boolean',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+      },
+    },
   },
   {
     lexicon: 1,
@@ -1255,11 +1627,11 @@ export const methodSchemas: MethodSchema[] = [
         required: ['thread'],
         properties: {
           thread: {
-            $ref: '#/$defs/post',
+            $ref: '#/$defs/appBskyGetPostThreadPost',
           },
         },
         $defs: {
-          post: {
+          appBskyGetPostThreadPost: {
             type: 'object',
             required: [
               'uri',
@@ -1279,7 +1651,7 @@ export const methodSchemas: MethodSchema[] = [
                 type: 'string',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetPostThreadUser',
               },
               record: {
                 type: 'object',
@@ -1287,18 +1659,18 @@ export const methodSchemas: MethodSchema[] = [
               embed: {
                 oneOf: [
                   {
-                    $ref: '#/$defs/recordEmbed',
+                    $ref: '#/$defs/appBskyGetPostThreadRecordEmbed',
                   },
                   {
-                    $ref: '#/$defs/externalEmbed',
+                    $ref: '#/$defs/appBskyGetPostThreadExternalEmbed',
                   },
                   {
-                    $ref: '#/$defs/unknownEmbed',
+                    $ref: '#/$defs/appBskyGetPostThreadUnknownEmbed',
                   },
                 ],
               },
               parent: {
-                $ref: '#/$defs/post',
+                $ref: '#/$defs/appBskyGetPostThreadPost',
               },
               replyCount: {
                 type: 'number',
@@ -1306,7 +1678,7 @@ export const methodSchemas: MethodSchema[] = [
               replies: {
                 type: 'array',
                 items: {
-                  $ref: '#/$defs/post',
+                  $ref: '#/$defs/appBskyGetPostThreadPost',
                 },
               },
               likeCount: {
@@ -1332,7 +1704,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          user: {
+          appBskyGetPostThreadUser: {
             type: 'object',
             required: ['did', 'name'],
             properties: {
@@ -1348,7 +1720,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          recordEmbed: {
+          appBskyGetPostThreadRecordEmbed: {
             type: 'object',
             required: ['type', 'author', 'record'],
             properties: {
@@ -1356,14 +1728,14 @@ export const methodSchemas: MethodSchema[] = [
                 const: 'record',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetPostThreadUser',
               },
               record: {
                 type: 'object',
               },
             },
           },
-          externalEmbed: {
+          appBskyGetPostThreadExternalEmbed: {
             type: 'object',
             required: ['type', 'uri', 'title', 'description', 'imageUri'],
             properties: {
@@ -1384,7 +1756,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          unknownEmbed: {
+          appBskyGetPostThreadUnknownEmbed: {
             type: 'object',
             required: ['type'],
             properties: {
@@ -1394,6 +1766,145 @@ export const methodSchemas: MethodSchema[] = [
                   enum: ['record', 'external'],
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      post: {
+        type: 'object',
+        required: [
+          'uri',
+          'cid',
+          'author',
+          'record',
+          'replyCount',
+          'likeCount',
+          'repostCount',
+          'indexedAt',
+        ],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetPostThreadUser',
+          },
+          record: {
+            type: 'object',
+          },
+          embed: {
+            oneOf: [
+              {
+                $ref: '#/$defs/appBskyGetPostThreadRecordEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetPostThreadExternalEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetPostThreadUnknownEmbed',
+              },
+            ],
+          },
+          parent: {
+            $ref: '#/$defs/appBskyGetPostThreadPost',
+          },
+          replyCount: {
+            type: 'number',
+          },
+          replies: {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/appBskyGetPostThreadPost',
+            },
+          },
+          likeCount: {
+            type: 'number',
+          },
+          repostCount: {
+            type: 'number',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          myState: {
+            type: 'object',
+            properties: {
+              repost: {
+                type: 'string',
+              },
+              like: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        type: 'object',
+        required: ['did', 'name'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      recordEmbed: {
+        type: 'object',
+        required: ['type', 'author', 'record'],
+        properties: {
+          type: {
+            const: 'record',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetPostThreadUser',
+          },
+          record: {
+            type: 'object',
+          },
+        },
+      },
+      externalEmbed: {
+        type: 'object',
+        required: ['type', 'uri', 'title', 'description', 'imageUri'],
+        properties: {
+          type: {
+            const: 'external',
+          },
+          uri: {
+            type: 'string',
+          },
+          title: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          imageUri: {
+            type: 'string',
+          },
+        },
+      },
+      unknownEmbed: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['record', 'external'],
             },
           },
         },
@@ -1449,7 +1960,7 @@ export const methodSchemas: MethodSchema[] = [
           badges: {
             type: 'array',
             items: {
-              $ref: '#/$defs/badge',
+              $ref: '#/$defs/appBskyGetProfileBadge',
             },
           },
           myState: {
@@ -1462,7 +1973,7 @@ export const methodSchemas: MethodSchema[] = [
           },
         },
         $defs: {
-          badge: {
+          appBskyGetProfileBadge: {
             type: 'object',
             required: ['uri', 'cid'],
             properties: {
@@ -1505,6 +2016,52 @@ export const methodSchemas: MethodSchema[] = [
                 format: 'date-time',
               },
             },
+          },
+        },
+      },
+    },
+    defs: {
+      badge: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          error: {
+            type: 'string',
+          },
+          issuer: {
+            type: 'object',
+            required: ['did', 'name', 'displayName'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              name: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+          assertion: {
+            type: 'object',
+            required: ['type'],
+            properties: {
+              type: {
+                type: 'string',
+              },
+            },
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
           },
         },
       },
@@ -1568,6 +2125,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1639,6 +2197,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1710,6 +2269,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1730,11 +2290,14 @@ export const methodSchemas: MethodSchema[] = [
             format: 'date-time',
           },
         },
+        $defs: {},
       },
     },
     output: {
       encoding: 'application/json',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
 ]
@@ -1751,16 +2314,16 @@ export const recordSchemas: RecordSchema[] = [
         assertion: {
           oneOf: [
             {
-              $ref: '#/$defs/inviteAssertion',
+              $ref: '#/$defs/appBskyBadgeInviteAssertion',
             },
             {
-              $ref: '#/$defs/employeeAssertion',
+              $ref: '#/$defs/appBskyBadgeEmployeeAssertion',
             },
             {
-              $ref: '#/$defs/tagAssertion',
+              $ref: '#/$defs/appBskyBadgeTagAssertion',
             },
             {
-              $ref: '#/$defs/unknownAssertion',
+              $ref: '#/$defs/appBskyBadgeUnknownAssertion',
             },
           ],
         },
@@ -1773,7 +2336,7 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        inviteAssertion: {
+        appBskyBadgeInviteAssertion: {
           type: 'object',
           required: ['type'],
           properties: {
@@ -1782,7 +2345,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        employeeAssertion: {
+        appBskyBadgeEmployeeAssertion: {
           type: 'object',
           required: ['type'],
           properties: {
@@ -1791,7 +2354,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        tagAssertion: {
+        appBskyBadgeTagAssertion: {
           type: 'object',
           required: ['type', 'tag'],
           properties: {
@@ -1804,7 +2367,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        unknownAssertion: {
+        appBskyBadgeUnknownAssertion: {
           type: 'object',
           required: ['type'],
           properties: {
@@ -1813,6 +2376,51 @@ export const recordSchemas: RecordSchema[] = [
               not: {
                 enum: ['invite', 'employee', 'tag'],
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      inviteAssertion: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            const: 'invite',
+          },
+        },
+      },
+      employeeAssertion: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            const: 'employee',
+          },
+        },
+      },
+      tagAssertion: {
+        type: 'object',
+        required: ['type', 'tag'],
+        properties: {
+          type: {
+            const: 'tag',
+          },
+          tag: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      unknownAssertion: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['invite', 'employee', 'tag'],
             },
           },
         },
@@ -1836,6 +2444,7 @@ export const recordSchemas: RecordSchema[] = [
           format: 'date-time',
         },
       },
+      $defs: {},
     },
   },
   {
@@ -1847,7 +2456,7 @@ export const recordSchemas: RecordSchema[] = [
       required: ['subject', 'createdAt'],
       properties: {
         subject: {
-          $ref: '#/$defs/subject',
+          $ref: '#/$defs/appBskyLikeSubject',
         },
         createdAt: {
           type: 'string',
@@ -1855,7 +2464,7 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        subject: {
+        appBskyLikeSubject: {
           type: 'object',
           required: ['uri', 'cid'],
           properties: {
@@ -1865,6 +2474,20 @@ export const recordSchemas: RecordSchema[] = [
             cid: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      subject: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
           },
         },
       },
@@ -1882,12 +2505,12 @@ export const recordSchemas: RecordSchema[] = [
         media: {
           type: 'array',
           items: {
-            $ref: '#/$defs/mediaEmbed',
+            $ref: '#/$defs/appBskyMediaEmbedMediaEmbed',
           },
         },
       },
       $defs: {
-        mediaEmbed: {
+        appBskyMediaEmbedMediaEmbed: {
           type: 'object',
           required: ['original'],
           properties: {
@@ -1895,14 +2518,14 @@ export const recordSchemas: RecordSchema[] = [
               type: 'string',
             },
             thumb: {
-              $ref: '#/$defs/mediaEmbedBlob',
+              $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
             },
             original: {
-              $ref: '#/$defs/mediaEmbedBlob',
+              $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
             },
           },
         },
-        mediaEmbedBlob: {
+        appBskyMediaEmbedMediaEmbedBlob: {
           type: 'object',
           required: ['mimeType', 'blobId'],
           properties: {
@@ -1912,6 +2535,35 @@ export const recordSchemas: RecordSchema[] = [
             blobId: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      mediaEmbed: {
+        type: 'object',
+        required: ['original'],
+        properties: {
+          alt: {
+            type: 'string',
+          },
+          thumb: {
+            $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
+          },
+          original: {
+            $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
+          },
+        },
+      },
+      mediaEmbedBlob: {
+        type: 'object',
+        required: ['mimeType', 'blobId'],
+        properties: {
+          mimeType: {
+            type: 'string',
+          },
+          blobId: {
+            type: 'string',
           },
         },
       },
@@ -1930,17 +2582,17 @@ export const recordSchemas: RecordSchema[] = [
           maxLength: 256,
         },
         entities: {
-          $ref: '#/$defs/entity',
+          $ref: '#/$defs/appBskyPostEntity',
         },
         reply: {
           type: 'object',
           required: ['root', 'parent'],
           properties: {
             root: {
-              $ref: '#/$defs/postRef',
+              $ref: '#/$defs/appBskyPostPostRef',
             },
             parent: {
-              $ref: '#/$defs/postRef',
+              $ref: '#/$defs/appBskyPostPostRef',
             },
           },
         },
@@ -1950,26 +2602,14 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        postRef: {
-          type: 'object',
-          required: ['uri', 'cid'],
-          properties: {
-            uri: {
-              type: 'string',
-            },
-            cid: {
-              type: 'string',
-            },
-          },
-        },
-        entity: {
+        appBskyPostEntity: {
           type: 'array',
           items: {
             type: 'object',
             required: ['index', 'type', 'value'],
             properties: {
               index: {
-                $ref: '#/$defs/textSlice',
+                $ref: '#/$defs/appBskyPostTextSlice',
               },
               type: {
                 type: 'string',
@@ -1982,7 +2622,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        textSlice: {
+        appBskyPostTextSlice: {
           type: 'array',
           items: [
             {
@@ -1995,6 +2635,64 @@ export const recordSchemas: RecordSchema[] = [
           minItems: 2,
           maxItems: 2,
         },
+        appBskyPostPostRef: {
+          type: 'object',
+          required: ['uri', 'cid'],
+          properties: {
+            uri: {
+              type: 'string',
+            },
+            cid: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      postRef: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+        },
+      },
+      entity: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['index', 'type', 'value'],
+          properties: {
+            index: {
+              $ref: '#/$defs/appBskyPostTextSlice',
+            },
+            type: {
+              type: 'string',
+              $comment: "Expected values are 'mention', 'hashtag', and 'link'.",
+            },
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      textSlice: {
+        type: 'array',
+        items: [
+          {
+            type: 'number',
+          },
+          {
+            type: 'number',
+          },
+        ],
+        minItems: 2,
+        maxItems: 2,
       },
     },
   },
@@ -2017,12 +2715,12 @@ export const recordSchemas: RecordSchema[] = [
         badges: {
           type: 'array',
           items: {
-            $ref: '#/$defs/badgeRef',
+            $ref: '#/$defs/appBskyProfileBadgeRef',
           },
         },
       },
       $defs: {
-        badgeRef: {
+        appBskyProfileBadgeRef: {
           type: 'object',
           required: ['uri', 'cid'],
           properties: {
@@ -2032,6 +2730,20 @@ export const recordSchemas: RecordSchema[] = [
             cid: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      badgeRef: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
           },
         },
       },
@@ -2046,7 +2758,7 @@ export const recordSchemas: RecordSchema[] = [
       required: ['subject', 'createdAt'],
       properties: {
         subject: {
-          $ref: '#/$defs/subject',
+          $ref: '#/$defs/appBskyRepostSubject',
         },
         createdAt: {
           type: 'string',
@@ -2054,7 +2766,7 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        subject: {
+        appBskyRepostSubject: {
           type: 'object',
           required: ['uri', 'cid'],
           properties: {
@@ -2064,6 +2776,20 @@ export const recordSchemas: RecordSchema[] = [
             cid: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      subject: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
           },
         },
       },

--- a/packages/api/src/types/app/bsky/badge.ts
+++ b/packages/api/src/types/app/bsky/badge.ts
@@ -3,28 +3,28 @@
 */
 export interface Record {
   assertion:
-    | InviteAssertion
-    | EmployeeAssertion
-    | TagAssertion
-    | UnknownAssertion;
+    | AppBskyBadgeInviteAssertion
+    | AppBskyBadgeEmployeeAssertion
+    | AppBskyBadgeTagAssertion
+    | AppBskyBadgeUnknownAssertion;
   subject: string;
   createdAt: string;
   [k: string]: unknown;
 }
-export interface InviteAssertion {
+export interface AppBskyBadgeInviteAssertion {
   type: 'invite';
   [k: string]: unknown;
 }
-export interface EmployeeAssertion {
+export interface AppBskyBadgeEmployeeAssertion {
   type: 'employee';
   [k: string]: unknown;
 }
-export interface TagAssertion {
+export interface AppBskyBadgeTagAssertion {
   type: 'tag';
   tag: string;
   [k: string]: unknown;
 }
-export interface UnknownAssertion {
+export interface AppBskyBadgeUnknownAssertion {
   type: string;
   [k: string]: unknown;
 }

--- a/packages/api/src/types/app/bsky/getAuthorFeed.ts
+++ b/packages/api/src/types/app/bsky/getAuthorFeed.ts
@@ -16,16 +16,19 @@ export interface CallOptions {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  feed: FeedItem[];
+  feed: AppBskyGetAuthorFeedFeedItem[];
 }
-export interface FeedItem {
+export interface AppBskyGetAuthorFeedFeedItem {
   cursor: string;
   uri: string;
   cid: string;
-  author: User;
-  repostedBy?: User;
+  author: AppBskyGetAuthorFeedUser;
+  repostedBy?: AppBskyGetAuthorFeedUser;
   record: {};
-  embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
+  embed?:
+    | AppBskyGetAuthorFeedRecordEmbed
+    | AppBskyGetAuthorFeedExternalEmbed
+    | AppBskyGetAuthorFeedUnknownEmbed;
   replyCount: number;
   repostCount: number;
   likeCount: number;
@@ -35,24 +38,24 @@ export interface FeedItem {
     like?: string,
   };
 }
-export interface User {
+export interface AppBskyGetAuthorFeedUser {
   did: string;
   name: string;
   displayName?: string;
 }
-export interface RecordEmbed {
+export interface AppBskyGetAuthorFeedRecordEmbed {
   type: 'record';
-  author: User;
+  author: AppBskyGetAuthorFeedUser;
   record: {};
 }
-export interface ExternalEmbed {
+export interface AppBskyGetAuthorFeedExternalEmbed {
   type: 'external';
   uri: string;
   title: string;
   description: string;
   imageUri: string;
 }
-export interface UnknownEmbed {
+export interface AppBskyGetAuthorFeedUnknownEmbed {
   type: string;
 }
 

--- a/packages/api/src/types/app/bsky/getHomeFeed.ts
+++ b/packages/api/src/types/app/bsky/getHomeFeed.ts
@@ -16,16 +16,19 @@ export interface CallOptions {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  feed: FeedItem[];
+  feed: AppBskyGetHomeFeedFeedItem[];
 }
-export interface FeedItem {
+export interface AppBskyGetHomeFeedFeedItem {
   cursor: string;
   uri: string;
   cid: string;
-  author: User;
-  repostedBy?: User;
+  author: AppBskyGetHomeFeedUser;
+  repostedBy?: AppBskyGetHomeFeedUser;
   record: {};
-  embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
+  embed?:
+    | AppBskyGetHomeFeedRecordEmbed
+    | AppBskyGetHomeFeedExternalEmbed
+    | AppBskyGetHomeFeedUnknownEmbed;
   replyCount: number;
   repostCount: number;
   likeCount: number;
@@ -35,24 +38,24 @@ export interface FeedItem {
     like?: string,
   };
 }
-export interface User {
+export interface AppBskyGetHomeFeedUser {
   did: string;
   name: string;
   displayName?: string;
 }
-export interface RecordEmbed {
+export interface AppBskyGetHomeFeedRecordEmbed {
   type: 'record';
-  author: User;
+  author: AppBskyGetHomeFeedUser;
   record: {};
 }
-export interface ExternalEmbed {
+export interface AppBskyGetHomeFeedExternalEmbed {
   type: 'external';
   uri: string;
   title: string;
   description: string;
   imageUri: string;
 }
-export interface UnknownEmbed {
+export interface AppBskyGetHomeFeedUnknownEmbed {
   type: string;
 }
 

--- a/packages/api/src/types/app/bsky/getNotifications.ts
+++ b/packages/api/src/types/app/bsky/getNotifications.ts
@@ -15,9 +15,9 @@ export interface CallOptions {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  notifications: Notification[];
+  notifications: AppBskyGetNotificationsNotification[];
 }
-export interface Notification {
+export interface AppBskyGetNotificationsNotification {
   uri: string;
   cid: string;
   author: {

--- a/packages/api/src/types/app/bsky/getPostThread.ts
+++ b/packages/api/src/types/app/bsky/getPostThread.ts
@@ -15,17 +15,20 @@ export interface CallOptions {
 export type InputSchema = undefined
 
 export interface OutputSchema {
-  thread: Post;
+  thread: AppBskyGetPostThreadPost;
 }
-export interface Post {
+export interface AppBskyGetPostThreadPost {
   uri: string;
   cid: string;
-  author: User;
+  author: AppBskyGetPostThreadUser;
   record: {};
-  embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
-  parent?: Post;
+  embed?:
+    | AppBskyGetPostThreadRecordEmbed
+    | AppBskyGetPostThreadExternalEmbed
+    | AppBskyGetPostThreadUnknownEmbed;
+  parent?: AppBskyGetPostThreadPost;
   replyCount: number;
-  replies?: Post[];
+  replies?: AppBskyGetPostThreadPost[];
   likeCount: number;
   repostCount: number;
   indexedAt: string;
@@ -34,24 +37,24 @@ export interface Post {
     like?: string,
   };
 }
-export interface User {
+export interface AppBskyGetPostThreadUser {
   did: string;
   name: string;
   displayName?: string;
 }
-export interface RecordEmbed {
+export interface AppBskyGetPostThreadRecordEmbed {
   type: 'record';
-  author: User;
+  author: AppBskyGetPostThreadUser;
   record: {};
 }
-export interface ExternalEmbed {
+export interface AppBskyGetPostThreadExternalEmbed {
   type: 'external';
   uri: string;
   title: string;
   description: string;
   imageUri: string;
 }
-export interface UnknownEmbed {
+export interface AppBskyGetPostThreadUnknownEmbed {
   type: string;
 }
 

--- a/packages/api/src/types/app/bsky/getProfile.ts
+++ b/packages/api/src/types/app/bsky/getProfile.ts
@@ -21,12 +21,12 @@ export interface OutputSchema {
   followersCount: number;
   followsCount: number;
   postsCount: number;
-  badges: Badge[];
+  badges: AppBskyGetProfileBadge[];
   myState?: {
     follow?: string,
   };
 }
-export interface Badge {
+export interface AppBskyGetProfileBadge {
   uri: string;
   cid: string;
   error?: string;

--- a/packages/api/src/types/app/bsky/like.ts
+++ b/packages/api/src/types/app/bsky/like.ts
@@ -2,11 +2,11 @@
 * GENERATED CODE - DO NOT MODIFY
 */
 export interface Record {
-  subject: Subject;
+  subject: AppBskyLikeSubject;
   createdAt: string;
   [k: string]: unknown;
 }
-export interface Subject {
+export interface AppBskyLikeSubject {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/api/src/types/app/bsky/mediaEmbed.ts
+++ b/packages/api/src/types/app/bsky/mediaEmbed.ts
@@ -2,16 +2,16 @@
 * GENERATED CODE - DO NOT MODIFY
 */
 export interface Record {
-  media: MediaEmbed[];
+  media: AppBskyMediaEmbedMediaEmbed[];
   [k: string]: unknown;
 }
-export interface MediaEmbed {
+export interface AppBskyMediaEmbedMediaEmbed {
   alt?: string;
-  thumb?: MediaEmbedBlob;
-  original: MediaEmbedBlob;
+  thumb?: AppBskyMediaEmbedMediaEmbedBlob;
+  original: AppBskyMediaEmbedMediaEmbedBlob;
   [k: string]: unknown;
 }
-export interface MediaEmbedBlob {
+export interface AppBskyMediaEmbedMediaEmbedBlob {
   mimeType: string;
   blobId: string;
   [k: string]: unknown;

--- a/packages/api/src/types/app/bsky/post.ts
+++ b/packages/api/src/types/app/bsky/post.ts
@@ -5,9 +5,9 @@
  * @minItems 2
  * @maxItems 2
  */
-export type TextSlice = [number, number]
-export type Entity = {
-  index: TextSlice,
+export type AppBskyPostTextSlice = [number, number]
+export type AppBskyPostEntity = {
+  index: AppBskyPostTextSlice,
   type: string,
   value: string,
   [k: string]: unknown,
@@ -15,16 +15,16 @@ export type Entity = {
 
 export interface Record {
   text: string;
-  entities?: Entity;
+  entities?: AppBskyPostEntity;
   reply?: {
-    root: PostRef,
-    parent: PostRef,
+    root: AppBskyPostPostRef,
+    parent: AppBskyPostPostRef,
     [k: string]: unknown,
   };
   createdAt: string;
   [k: string]: unknown;
 }
-export interface PostRef {
+export interface AppBskyPostPostRef {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/api/src/types/app/bsky/profile.ts
+++ b/packages/api/src/types/app/bsky/profile.ts
@@ -4,10 +4,10 @@
 export interface Record {
   displayName: string;
   description?: string;
-  badges?: BadgeRef[];
+  badges?: AppBskyProfileBadgeRef[];
   [k: string]: unknown;
 }
-export interface BadgeRef {
+export interface AppBskyProfileBadgeRef {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/api/src/types/app/bsky/repost.ts
+++ b/packages/api/src/types/app/bsky/repost.ts
@@ -2,11 +2,11 @@
 * GENERATED CODE - DO NOT MODIFY
 */
 export interface Record {
-  subject: Subject;
+  subject: AppBskyRepostSubject;
   createdAt: string;
   [k: string]: unknown;
 }
-export interface Subject {
+export interface AppBskyRepostSubject {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/lex-cli/jest.config.js
+++ b/packages/lex-cli/jest.config.js
@@ -1,0 +1,6 @@
+const base = require('../../jest.config.base.js')
+
+module.exports = {
+  ...base,
+  displayName: 'Lexicon CLI',
+}

--- a/packages/lex-cli/package.json
+++ b/packages/lex-cli/package.json
@@ -6,6 +6,7 @@
   },
   "main": "src/index.ts",
   "scripts": {
+    "test": "jest",
     "prettier": "prettier --check src/",
     "prettier:fix": "prettier --write src/",
     "lint": "eslint . --ext .ts,.tsx",
@@ -23,6 +24,7 @@
     "ajv-formats": "^2.1.1",
     "chalk": "^5.1.1",
     "commander": "^9.4.0",
+    "json-pointer": "^0.6.2",
     "json-schema-to-typescript": "^11.0.2",
     "ts-morph": "^16.0.0",
     "yesno": "^0.4.0"

--- a/packages/lex-cli/src/index.ts
+++ b/packages/lex-cli/src/index.ts
@@ -13,6 +13,7 @@ import {
   printFileDiff,
   applyFileDiff,
 } from './util'
+import { resolveAllRefs } from './refs'
 import * as mdGen from './mdgen'
 import { genClientApi } from './codegen/client'
 import { genServerApi } from './codegen/server'
@@ -63,6 +64,7 @@ program
       process.exit(0)
     }
     const schemas = readAllSchemas(schemaPaths)
+    resolveAllRefs(schemas)
     await mdGen.process(outFilePath, schemas)
   })
 
@@ -72,6 +74,7 @@ program
   .argument('<schemas...>', 'paths of the schema files to include', toPaths)
   .action((schemaPaths: string[]) => {
     const schemas = readAllSchemas(schemaPaths)
+    resolveAllRefs(schemas)
     console.log(genTsObj(schemas))
   })
 
@@ -82,6 +85,7 @@ program
   .argument('<schemas...>', 'paths of the schema files to include', toPaths)
   .action(async (outDir: string, schemaPaths: string[]) => {
     const schemas = readAllSchemas(schemaPaths)
+    resolveAllRefs(schemas)
     const api = await genClientApi(schemas)
     const diff = genFileDiff(outDir, api)
     console.log('This will write the following files:')
@@ -105,6 +109,7 @@ program
   .argument('<schemas...>', 'paths of the schema files to include', toPaths)
   .action(async (outDir: string, schemaPaths: string[]) => {
     const schemas = readAllSchemas(schemaPaths)
+    resolveAllRefs(schemas)
     const api = await genServerApi(schemas)
     const diff = genFileDiff(outDir, api)
     console.log('This will write the following files:')

--- a/packages/lex-cli/src/refs.ts
+++ b/packages/lex-cli/src/refs.ts
@@ -1,0 +1,147 @@
+import { Schema, isValidRecordSchema, isValidMethodSchema } from '@adxp/lexicon'
+import pointer from 'json-pointer'
+import { toCamelCase } from './codegen/util'
+
+export function resolveAllRefs(schemas: Schema[]) {
+  for (const schema of schemas) {
+    try {
+      resolveRefs(schema, schemas)
+    } catch (e) {
+      console.error('Failed to resolve references in', schema.id)
+      throw e
+    }
+  }
+  for (const schema of schemas) {
+    try {
+      normalizeRefs(schema)
+    } catch (e) {
+      console.error('Failed to normalize references in', schema.id)
+      throw e
+    }
+  }
+}
+
+function normalizeRefs(schema: Schema) {
+  for (const [$ref, setRef] of findRefs(schema)) {
+    setRef(`#/$defs/${refToKey($ref, schema.id)}`)
+  }
+}
+
+function resolveRefs(doc: Schema, docs: Schema[]) {
+  if (isValidRecordSchema(doc)) {
+    if (doc.record) {
+      doc.record.$defs = resolveJsonSchemaRefs(doc.record, doc, docs)
+    }
+  } else if (isValidMethodSchema(doc)) {
+    if (doc.input?.schema) {
+      doc.input.schema.$defs = resolveJsonSchemaRefs(
+        doc.input.schema,
+        doc,
+        docs,
+      )
+    }
+    if (doc.output?.schema) {
+      doc.output.schema.$defs = resolveJsonSchemaRefs(
+        doc.output.schema,
+        doc,
+        docs,
+      )
+    }
+  } else {
+    throw new Error('Unknown lexicon schema')
+  }
+}
+
+function resolveJsonSchemaRefs(
+  jsonSchema: any,
+  doc: Schema,
+  docs: Schema[],
+  $defs = {},
+): Record<string, any> {
+  if (!isObj(jsonSchema)) return {}
+  for (const [$ref] of findRefs(jsonSchema)) {
+    let targetDoc = doc
+    if ($ref.startsWith('lex:')) {
+      // external doc ref
+      targetDoc = findInput($ref, docs)
+    }
+
+    let key = refToKey($ref, targetDoc.id)
+    if (!(key in $defs)) {
+      // copy the definition into our dictionary
+      const def = clone(lookup(targetDoc, $ref))
+      $defs[key] = def
+
+      // recurse into the definition
+      resolveJsonSchemaRefs(def, targetDoc, docs, $defs)
+    }
+  }
+  return $defs
+}
+
+function clone(v: any): any {
+  return JSON.parse(JSON.stringify(v))
+}
+
+type SetRef = (v: string) => void
+function findRefs(obj: Record<string, any>): [string, SetRef][] {
+  let items: [string, SetRef][] = []
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === '$ref') {
+      items.push([
+        value,
+        (newValue) => {
+          obj[key] = newValue
+        },
+      ])
+    } else if (value && typeof value === 'object') {
+      items = items.concat(findRefs(value))
+    }
+  }
+  return items
+}
+
+function findInput($ref: string, inputs: Schema[]): Schema {
+  const id = extractId($ref)
+  const input = inputs.find((i) => i.id === id)
+  if (!input) {
+    throw new Error(`Schema not found: ${$ref}`)
+  }
+  return input
+}
+
+function findAvailableKey($ref: string, $defs: Record<string, any>): string {
+  const keys = Object.keys($defs)
+
+  const name = $ref.split('/').pop() || ''
+  if (!keys.includes(name)) return name
+
+  let i = 2
+  do {
+    if (!keys.includes(`${name}${i}`)) return `${name}${i}`
+    i++
+  } while (i < 1e3)
+
+  throw new Error(`Unable to find a suitable keyname for ${$ref}`)
+}
+
+function lookup(obj: any, $ref: string): any {
+  const res = pointer.get(obj, $ref.split('#').pop() || '')
+  if (!res) throw new Error(`Unable to resolve $ref: ${$ref}`)
+  return res
+}
+
+const RE = /^lex:([a-z0-9-\.]+)/i
+function extractId(v: string): string {
+  return RE.exec(v)?.[1] || ''
+}
+
+function refToKey(ref: string, id: string): string {
+  id = extractId(ref) || id
+  const name = ref.split('/').pop() || ''
+  return toCamelCase(`${id}.${name}`)
+}
+
+function isObj(v: any): v is Object {
+  return v && typeof v === 'object' && !Array.isArray(v)
+}

--- a/packages/lex-cli/src/util.ts
+++ b/packages/lex-cli/src/util.ts
@@ -54,14 +54,16 @@ export function readSchema(path: string): Schema {
   }
   if (obj.type === 'query' || obj.type === 'procedure') {
     try {
-      return methodSchema.parse(obj)
+      methodSchema.parse(obj)
+      return obj
     } catch (e) {
       console.error(`Invalid method schema in file`, path)
       throw e
     }
   } else if (obj.type === 'record') {
     try {
-      return recordSchema.parse(obj)
+      recordSchema.parse(obj)
+      return obj
     } catch (e) {
       console.error(`Invalid record schema in file`, path)
       throw e

--- a/packages/lex-cli/tests/refs.test.ts
+++ b/packages/lex-cli/tests/refs.test.ts
@@ -1,0 +1,215 @@
+import { Schema } from '@adxp/lexicon'
+import { resolveAllRefs } from '../src/refs'
+
+describe('Reference resolution', () => {
+  it('Correctly resolves references within itself', () => {
+    const obj = {
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: { $ref: '#/$defs/subject' },
+        },
+      },
+      $defs: {
+        subject: { type: 'string' },
+      },
+    }
+    resolveAllRefs([obj] as Schema[])
+    expect(obj).toEqual({
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: {
+            $ref: '#/$defs/appBskyLikeSubject',
+          },
+        },
+        $defs: {
+          appBskyLikeSubject: {
+            type: 'string',
+          },
+        },
+      },
+      $defs: {
+        subject: {
+          type: 'string',
+        },
+      },
+    })
+  })
+  it('Correctly resolves cascading references', () => {
+    const obj = {
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: { $ref: '#/$defs/subjectArr' },
+        },
+      },
+      $defs: {
+        subjectArr: {
+          type: 'array',
+          items: { type: { $ref: '#/$defs/subject' } },
+        },
+        subject: {
+          type: 'string',
+        },
+      },
+    }
+    resolveAllRefs([obj] as Schema[])
+    expect(obj).toEqual({
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: {
+            $ref: '#/$defs/appBskyLikeSubjectArr',
+          },
+        },
+        $defs: {
+          appBskyLikeSubjectArr: {
+            type: 'array',
+            items: { type: { $ref: '#/$defs/appBskyLikeSubject' } },
+          },
+          appBskyLikeSubject: {
+            type: 'string',
+          },
+        },
+      },
+      $defs: {
+        subjectArr: {
+          type: 'array',
+          items: { type: { $ref: '#/$defs/appBskyLikeSubject' } },
+        },
+        subject: {
+          type: 'string',
+        },
+      },
+    })
+  })
+  it('Correctly resolves references to other lexicons', () => {
+    const obj = {
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: { $ref: '#/$defs/subject' },
+          otherSubject: { $ref: 'lex:app.bsky.repost#/$defs/subject' },
+          displayName: { $ref: 'lex:app.bsky.profile#/$defs/displayName' },
+        },
+      },
+      $defs: {
+        subject: { type: 'string' },
+      },
+    }
+    const obj2 = {
+      lexicon: 1,
+      id: 'app.bsky.repost',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: { $ref: '#/$defs/subject' },
+        },
+      },
+      $defs: {
+        subject: { type: 'string' },
+      },
+    }
+    const obj3 = {
+      lexicon: 1,
+      id: 'app.bsky.profile',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          displayName: { $ref: '#/$defs/displayName' },
+        },
+      },
+      $defs: {
+        displayName: { type: 'string' },
+      },
+    }
+    resolveAllRefs([obj, obj2, obj3] as Schema[])
+    expect(obj).toEqual({
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: {
+            $ref: '#/$defs/appBskyLikeSubject',
+          },
+          otherSubject: {
+            $ref: '#/$defs/appBskyRepostSubject',
+          },
+          displayName: {
+            $ref: '#/$defs/appBskyProfileDisplayName',
+          },
+        },
+        $defs: {
+          appBskyLikeSubject: {
+            type: 'string',
+          },
+          appBskyRepostSubject: {
+            type: 'string',
+          },
+          appBskyProfileDisplayName: {
+            type: 'string',
+          },
+        },
+      },
+      $defs: {
+        subject: {
+          type: 'string',
+        },
+      },
+    })
+  })
+  it('Throws on an invalid reference', () => {
+    const obj = {
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: { $ref: '#/$defs/bad' },
+        },
+      },
+      $defs: {
+        subject: { type: 'string' },
+      },
+    }
+    expect(() => resolveAllRefs([obj] as Schema[])).toThrow()
+  })
+  it('Throws on a schema not found', () => {
+    const obj = {
+      lexicon: 1,
+      id: 'app.bsky.like',
+      type: 'record',
+      record: {
+        type: 'object',
+        properties: {
+          subject: { $ref: 'lex:com.foo.bar#/$defs/bad' },
+        },
+      },
+      $defs: {
+        subject: { type: 'string' },
+      },
+    }
+    expect(() => resolveAllRefs([obj] as Schema[])).toThrow()
+  })
+})

--- a/packages/lexicon/src/types.ts
+++ b/packages/lexicon/src/types.ts
@@ -10,8 +10,13 @@ export const recordSchema = z.object({
   revision: z.number().optional(),
   description: z.string().optional(),
   record: z.any().optional(),
+  defs: z.any().optional(),
 })
 export type RecordSchema = z.infer<typeof recordSchema>
+
+export function isValidRecordSchema(v: unknown): v is RecordSchema {
+  return recordSchema.safeParse(v).success
+}
 
 export class RecordSchemaMalformedError extends Error {
   constructor(
@@ -27,6 +32,7 @@ export class RecordSchemaMalformedError extends Error {
 
 export const methodSchemaBody = z.object({
   encoding: z.union([z.string(), z.string().array()]),
+  description: z.string().optional(),
   schema: z.any().optional(),
 })
 export type MethodSchemaBody = z.infer<typeof methodSchemaBody>
@@ -58,6 +64,7 @@ export const methodSchema = z.object({
   input: methodSchemaBody.optional(),
   output: methodSchemaBody.optional(),
   errors: methodSchemaError.array().optional(),
+  defs: z.any().optional(),
 })
 export type MethodSchema = z.infer<typeof methodSchema>
 

--- a/packages/server/src/api/app/bsky/getPostThread.ts
+++ b/packages/server/src/api/app/bsky/getPostThread.ts
@@ -46,10 +46,10 @@ export default function (server: Server) {
 
 const getReplies = async (
   db: Kysely<DatabaseSchema>,
-  parent: GetPostThread.Post,
+  parent: GetPostThread.AppBskyGetPostThreadPost,
   depth: number,
   requester: string,
-): Promise<GetPostThread.Post[]> => {
+): Promise<GetPostThread.AppBskyGetPostThreadPost[]> => {
   const res = await postInfoBuilder(db, requester)
     .where('post.replyParent', '=', parent.uri)
     .orderBy('post.createdAt', 'desc')
@@ -122,8 +122,8 @@ const postInfoBuilder = (db: Kysely<DatabaseSchema>, requester: string) => {
 // unfortunately not type-checked yet, so change with caution!
 const rowToPost = (
   row: any,
-  parent?: GetPostThread.Post,
-): GetPostThread.Post => {
+  parent?: GetPostThread.AppBskyGetPostThreadPost,
+): GetPostThread.AppBskyGetPostThreadPost => {
   return {
     uri: row.uri,
     cid: row.cid,

--- a/packages/server/src/api/app/bsky/util/feed.ts
+++ b/packages/server/src/api/app/bsky/util/feed.ts
@@ -1,4 +1,5 @@
-import { AppBskyGetAuthorFeed, AppBskyGetHomeFeed } from '@adxp/api'
+import * as GetAuthorFeed from '../../../../lexicon/types/app/bsky/getAuthorFeed'
+import * as GetHomeFeed from '../../../../lexicon/types/app/bsky/getHomeFeed'
 
 // Present post and repost results into FeedItems
 // @TODO add embeds
@@ -35,7 +36,8 @@ export enum FeedAlgorithm {
   ReverseChronological = 'reverse-chronological',
 }
 
-type FeedItem = AppBskyGetAuthorFeed.FeedItem & AppBskyGetHomeFeed.FeedItem
+type FeedItem = GetAuthorFeed.AppBskyGetAuthorFeedFeedItem &
+  GetHomeFeed.AppBskyGetHomeFeedFeedItem
 
 type FeedRow = {
   type: 'post' | 'repost'

--- a/packages/server/src/db/records/badge.ts
+++ b/packages/server/src/db/records/badge.ts
@@ -79,7 +79,7 @@ const insertFn =
       creator: uri.host,
       subject: obj.subject,
       assertionType: obj.assertion.type,
-      assertionTag: (obj.assertion as Badge.TagAssertion).tag,
+      assertionTag: (obj.assertion as Badge.AppBskyBadgeTagAssertion).tag,
       createdAt: obj.createdAt,
       indexedAt: new Date().toISOString(),
     }

--- a/packages/server/src/lexicon/schemas.ts
+++ b/packages/server/src/lexicon/schemas.ts
@@ -29,6 +29,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -47,6 +48,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     errors: [
@@ -80,6 +82,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'number',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -92,6 +95,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -114,6 +118,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -132,6 +137,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -143,11 +149,15 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {},
     input: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -158,11 +168,15 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {},
     input: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -173,11 +187,15 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {},
     input: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: '',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -203,6 +221,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -225,6 +244,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -236,13 +256,13 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       validate: {
         type: 'boolean',
-        description: 'Validate the records?',
         default: true,
+        description: 'Validate the records?',
       },
     },
     input: {
@@ -306,11 +326,14 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
     output: {
       encoding: 'application/json',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
   {
@@ -321,23 +344,26 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record collection.',
         required: true,
+        description: 'The NSID of the record collection.',
       },
       validate: {
         type: 'boolean',
-        description: 'Validate the record?',
         default: true,
+        description: 'Validate the record?',
       },
     },
     input: {
       encoding: 'application/json',
-      schema: {},
+      description: 'The record to create',
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: 'application/json',
@@ -352,6 +378,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -363,18 +390,18 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record collection.',
         required: true,
+        description: 'The NSID of the record collection.',
       },
       rkey: {
         type: 'string',
-        description: 'The key of the record.',
         required: true,
+        description: 'The key of the record.',
       },
     },
   },
@@ -387,8 +414,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       user: {
         type: 'string',
-        description: 'The username or DID of the repo.',
         required: true,
+        description: 'The username or DID of the repo.',
       },
     },
     output: {
@@ -416,6 +443,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'boolean',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -427,24 +455,24 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       user: {
         type: 'string',
-        description: 'The username or DID of the repo.',
         required: true,
+        description: 'The username or DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the collection.',
         required: true,
+        description: 'The NSID of the collection.',
       },
       rkey: {
         type: 'string',
-        description: 'The key of the record.',
         required: true,
+        description: 'The key of the record.',
       },
       cid: {
         type: 'string',
+        required: false,
         description:
           'The CID of the version of the record. If not specified, then return the most recent version.',
-        required: false,
       },
     },
     output: {
@@ -463,6 +491,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'object',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -474,19 +503,19 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       user: {
         type: 'string',
-        description: 'The username or DID of the repo.',
         required: true,
+        description: 'The username or DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record type.',
         required: true,
+        description: 'The NSID of the record type.',
       },
       limit: {
         type: 'number',
-        description: 'The number of records to return. TODO-max number?',
-        default: 50,
         minimum: 1,
+        default: 50,
+        description: 'The number of records to return. TODO-max number?',
       },
       before: {
         type: 'string',
@@ -527,6 +556,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -538,28 +568,30 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       collection: {
         type: 'string',
-        description: 'The NSID of the record type.',
         required: true,
+        description: 'The NSID of the record type.',
       },
       rkey: {
         type: 'string',
-        description: 'The TID of the record.',
         required: true,
+        description: 'The TID of the record.',
       },
       validate: {
         type: 'boolean',
-        description: 'Validate the record?',
         default: true,
+        description: 'Validate the record?',
       },
     },
     input: {
       encoding: 'application/json',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
     output: {
       encoding: 'application/json',
@@ -574,6 +606,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -593,6 +626,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -600,6 +634,7 @@ export const methodSchemas: MethodSchema[] = [
       schema: {
         type: 'object',
         properties: {},
+        $defs: {},
       },
     },
   },
@@ -622,6 +657,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
     output: {
@@ -629,6 +665,7 @@ export const methodSchemas: MethodSchema[] = [
       schema: {
         type: 'object',
         properties: {},
+        $defs: {},
       },
     },
     errors: [
@@ -662,6 +699,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -673,8 +711,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
       from: {
         type: 'string',
@@ -693,8 +731,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
     },
     output: {
@@ -707,6 +745,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'string',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -718,8 +757,8 @@ export const methodSchemas: MethodSchema[] = [
     parameters: {
       did: {
         type: 'string',
-        description: 'The DID of the repo.',
         required: true,
+        description: 'The DID of the repo.',
       },
     },
     input: {
@@ -753,12 +792,12 @@ export const methodSchemas: MethodSchema[] = [
           feed: {
             type: 'array',
             items: {
-              $ref: '#/$defs/feedItem',
+              $ref: '#/$defs/appBskyGetAuthorFeedFeedItem',
             },
           },
         },
         $defs: {
-          feedItem: {
+          appBskyGetAuthorFeedFeedItem: {
             type: 'object',
             required: [
               'cursor',
@@ -782,10 +821,10 @@ export const methodSchemas: MethodSchema[] = [
                 type: 'string',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetAuthorFeedUser',
               },
               repostedBy: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetAuthorFeedUser',
               },
               record: {
                 type: 'object',
@@ -793,13 +832,13 @@ export const methodSchemas: MethodSchema[] = [
               embed: {
                 oneOf: [
                   {
-                    $ref: '#/$defs/recordEmbed',
+                    $ref: '#/$defs/appBskyGetAuthorFeedRecordEmbed',
                   },
                   {
-                    $ref: '#/$defs/externalEmbed',
+                    $ref: '#/$defs/appBskyGetAuthorFeedExternalEmbed',
                   },
                   {
-                    $ref: '#/$defs/unknownEmbed',
+                    $ref: '#/$defs/appBskyGetAuthorFeedUnknownEmbed',
                   },
                 ],
               },
@@ -829,7 +868,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          user: {
+          appBskyGetAuthorFeedUser: {
             type: 'object',
             required: ['did', 'name'],
             properties: {
@@ -845,7 +884,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          recordEmbed: {
+          appBskyGetAuthorFeedRecordEmbed: {
             type: 'object',
             required: ['type', 'author', 'record'],
             properties: {
@@ -853,14 +892,14 @@ export const methodSchemas: MethodSchema[] = [
                 const: 'record',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetAuthorFeedUser',
               },
               record: {
                 type: 'object',
               },
             },
           },
-          externalEmbed: {
+          appBskyGetAuthorFeedExternalEmbed: {
             type: 'object',
             required: ['type', 'uri', 'title', 'description', 'imageUri'],
             properties: {
@@ -881,7 +920,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          unknownEmbed: {
+          appBskyGetAuthorFeedUnknownEmbed: {
             type: 'object',
             required: ['type'],
             properties: {
@@ -891,6 +930,143 @@ export const methodSchemas: MethodSchema[] = [
                   enum: ['record', 'external'],
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      feedItem: {
+        type: 'object',
+        required: [
+          'cursor',
+          'uri',
+          'cid',
+          'author',
+          'record',
+          'replyCount',
+          'repostCount',
+          'likeCount',
+          'indexedAt',
+        ],
+        properties: {
+          cursor: {
+            type: 'string',
+          },
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetAuthorFeedUser',
+          },
+          repostedBy: {
+            $ref: '#/$defs/appBskyGetAuthorFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+          embed: {
+            oneOf: [
+              {
+                $ref: '#/$defs/appBskyGetAuthorFeedRecordEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetAuthorFeedExternalEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetAuthorFeedUnknownEmbed',
+              },
+            ],
+          },
+          replyCount: {
+            type: 'number',
+          },
+          repostCount: {
+            type: 'number',
+          },
+          likeCount: {
+            type: 'number',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          myState: {
+            type: 'object',
+            properties: {
+              repost: {
+                type: 'string',
+              },
+              like: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        type: 'object',
+        required: ['did', 'name'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      recordEmbed: {
+        type: 'object',
+        required: ['type', 'author', 'record'],
+        properties: {
+          type: {
+            const: 'record',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetAuthorFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+        },
+      },
+      externalEmbed: {
+        type: 'object',
+        required: ['type', 'uri', 'title', 'description', 'imageUri'],
+        properties: {
+          type: {
+            const: 'external',
+          },
+          uri: {
+            type: 'string',
+          },
+          title: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          imageUri: {
+            type: 'string',
+          },
+        },
+      },
+      unknownEmbed: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['record', 'external'],
             },
           },
         },
@@ -923,12 +1099,12 @@ export const methodSchemas: MethodSchema[] = [
           feed: {
             type: 'array',
             items: {
-              $ref: '#/$defs/feedItem',
+              $ref: '#/$defs/appBskyGetHomeFeedFeedItem',
             },
           },
         },
         $defs: {
-          feedItem: {
+          appBskyGetHomeFeedFeedItem: {
             type: 'object',
             required: [
               'cursor',
@@ -952,10 +1128,10 @@ export const methodSchemas: MethodSchema[] = [
                 type: 'string',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetHomeFeedUser',
               },
               repostedBy: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetHomeFeedUser',
               },
               record: {
                 type: 'object',
@@ -963,13 +1139,13 @@ export const methodSchemas: MethodSchema[] = [
               embed: {
                 oneOf: [
                   {
-                    $ref: '#/$defs/recordEmbed',
+                    $ref: '#/$defs/appBskyGetHomeFeedRecordEmbed',
                   },
                   {
-                    $ref: '#/$defs/externalEmbed',
+                    $ref: '#/$defs/appBskyGetHomeFeedExternalEmbed',
                   },
                   {
-                    $ref: '#/$defs/unknownEmbed',
+                    $ref: '#/$defs/appBskyGetHomeFeedUnknownEmbed',
                   },
                 ],
               },
@@ -999,7 +1175,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          user: {
+          appBskyGetHomeFeedUser: {
             type: 'object',
             required: ['did', 'name'],
             properties: {
@@ -1015,7 +1191,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          recordEmbed: {
+          appBskyGetHomeFeedRecordEmbed: {
             type: 'object',
             required: ['type', 'author', 'record'],
             properties: {
@@ -1023,14 +1199,14 @@ export const methodSchemas: MethodSchema[] = [
                 const: 'record',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetHomeFeedUser',
               },
               record: {
                 type: 'object',
               },
             },
           },
-          externalEmbed: {
+          appBskyGetHomeFeedExternalEmbed: {
             type: 'object',
             required: ['type', 'uri', 'title', 'description', 'imageUri'],
             properties: {
@@ -1051,7 +1227,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          unknownEmbed: {
+          appBskyGetHomeFeedUnknownEmbed: {
             type: 'object',
             required: ['type'],
             properties: {
@@ -1061,6 +1237,143 @@ export const methodSchemas: MethodSchema[] = [
                   enum: ['record', 'external'],
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      feedItem: {
+        type: 'object',
+        required: [
+          'cursor',
+          'uri',
+          'cid',
+          'author',
+          'record',
+          'replyCount',
+          'repostCount',
+          'likeCount',
+          'indexedAt',
+        ],
+        properties: {
+          cursor: {
+            type: 'string',
+          },
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetHomeFeedUser',
+          },
+          repostedBy: {
+            $ref: '#/$defs/appBskyGetHomeFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+          embed: {
+            oneOf: [
+              {
+                $ref: '#/$defs/appBskyGetHomeFeedRecordEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetHomeFeedExternalEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetHomeFeedUnknownEmbed',
+              },
+            ],
+          },
+          replyCount: {
+            type: 'number',
+          },
+          repostCount: {
+            type: 'number',
+          },
+          likeCount: {
+            type: 'number',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          myState: {
+            type: 'object',
+            properties: {
+              repost: {
+                type: 'string',
+              },
+              like: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        type: 'object',
+        required: ['did', 'name'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      recordEmbed: {
+        type: 'object',
+        required: ['type', 'author', 'record'],
+        properties: {
+          type: {
+            const: 'record',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetHomeFeedUser',
+          },
+          record: {
+            type: 'object',
+          },
+        },
+      },
+      externalEmbed: {
+        type: 'object',
+        required: ['type', 'uri', 'title', 'description', 'imageUri'],
+        properties: {
+          type: {
+            const: 'external',
+          },
+          uri: {
+            type: 'string',
+          },
+          title: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          imageUri: {
+            type: 'string',
+          },
+        },
+      },
+      unknownEmbed: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['record', 'external'],
             },
           },
         },
@@ -1128,6 +1441,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1146,6 +1460,7 @@ export const methodSchemas: MethodSchema[] = [
             type: 'number',
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1171,12 +1486,12 @@ export const methodSchemas: MethodSchema[] = [
           notifications: {
             type: 'array',
             items: {
-              $ref: '#/$defs/notification',
+              $ref: '#/$defs/appBskyGetNotificationsNotification',
             },
           },
         },
         $defs: {
-          notification: {
+          appBskyGetNotificationsNotification: {
             type: 'object',
             required: [
               'uri',
@@ -1234,6 +1549,63 @@ export const methodSchemas: MethodSchema[] = [
         },
       },
     },
+    defs: {
+      notification: {
+        type: 'object',
+        required: [
+          'uri',
+          'cid',
+          'author',
+          'reason',
+          'record',
+          'isRead',
+          'indexedAt',
+        ],
+        properties: {
+          uri: {
+            type: 'string',
+            format: 'uri',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            type: 'object',
+            required: ['did', 'name'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              name: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+          reason: {
+            type: 'string',
+            $comment:
+              "Expected values are 'like', 'repost', 'follow', 'badge', 'mention' and 'reply'.",
+          },
+          reasonSubject: {
+            type: 'string',
+          },
+          record: {
+            type: 'object',
+          },
+          isRead: {
+            type: 'boolean',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+        },
+      },
+    },
   },
   {
     lexicon: 1,
@@ -1255,11 +1627,11 @@ export const methodSchemas: MethodSchema[] = [
         required: ['thread'],
         properties: {
           thread: {
-            $ref: '#/$defs/post',
+            $ref: '#/$defs/appBskyGetPostThreadPost',
           },
         },
         $defs: {
-          post: {
+          appBskyGetPostThreadPost: {
             type: 'object',
             required: [
               'uri',
@@ -1279,7 +1651,7 @@ export const methodSchemas: MethodSchema[] = [
                 type: 'string',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetPostThreadUser',
               },
               record: {
                 type: 'object',
@@ -1287,18 +1659,18 @@ export const methodSchemas: MethodSchema[] = [
               embed: {
                 oneOf: [
                   {
-                    $ref: '#/$defs/recordEmbed',
+                    $ref: '#/$defs/appBskyGetPostThreadRecordEmbed',
                   },
                   {
-                    $ref: '#/$defs/externalEmbed',
+                    $ref: '#/$defs/appBskyGetPostThreadExternalEmbed',
                   },
                   {
-                    $ref: '#/$defs/unknownEmbed',
+                    $ref: '#/$defs/appBskyGetPostThreadUnknownEmbed',
                   },
                 ],
               },
               parent: {
-                $ref: '#/$defs/post',
+                $ref: '#/$defs/appBskyGetPostThreadPost',
               },
               replyCount: {
                 type: 'number',
@@ -1306,7 +1678,7 @@ export const methodSchemas: MethodSchema[] = [
               replies: {
                 type: 'array',
                 items: {
-                  $ref: '#/$defs/post',
+                  $ref: '#/$defs/appBskyGetPostThreadPost',
                 },
               },
               likeCount: {
@@ -1332,7 +1704,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          user: {
+          appBskyGetPostThreadUser: {
             type: 'object',
             required: ['did', 'name'],
             properties: {
@@ -1348,7 +1720,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          recordEmbed: {
+          appBskyGetPostThreadRecordEmbed: {
             type: 'object',
             required: ['type', 'author', 'record'],
             properties: {
@@ -1356,14 +1728,14 @@ export const methodSchemas: MethodSchema[] = [
                 const: 'record',
               },
               author: {
-                $ref: '#/$defs/user',
+                $ref: '#/$defs/appBskyGetPostThreadUser',
               },
               record: {
                 type: 'object',
               },
             },
           },
-          externalEmbed: {
+          appBskyGetPostThreadExternalEmbed: {
             type: 'object',
             required: ['type', 'uri', 'title', 'description', 'imageUri'],
             properties: {
@@ -1384,7 +1756,7 @@ export const methodSchemas: MethodSchema[] = [
               },
             },
           },
-          unknownEmbed: {
+          appBskyGetPostThreadUnknownEmbed: {
             type: 'object',
             required: ['type'],
             properties: {
@@ -1394,6 +1766,145 @@ export const methodSchemas: MethodSchema[] = [
                   enum: ['record', 'external'],
                 },
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      post: {
+        type: 'object',
+        required: [
+          'uri',
+          'cid',
+          'author',
+          'record',
+          'replyCount',
+          'likeCount',
+          'repostCount',
+          'indexedAt',
+        ],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetPostThreadUser',
+          },
+          record: {
+            type: 'object',
+          },
+          embed: {
+            oneOf: [
+              {
+                $ref: '#/$defs/appBskyGetPostThreadRecordEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetPostThreadExternalEmbed',
+              },
+              {
+                $ref: '#/$defs/appBskyGetPostThreadUnknownEmbed',
+              },
+            ],
+          },
+          parent: {
+            $ref: '#/$defs/appBskyGetPostThreadPost',
+          },
+          replyCount: {
+            type: 'number',
+          },
+          replies: {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/appBskyGetPostThreadPost',
+            },
+          },
+          likeCount: {
+            type: 'number',
+          },
+          repostCount: {
+            type: 'number',
+          },
+          indexedAt: {
+            type: 'string',
+            format: 'date-time',
+          },
+          myState: {
+            type: 'object',
+            properties: {
+              repost: {
+                type: 'string',
+              },
+              like: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        type: 'object',
+        required: ['did', 'name'],
+        properties: {
+          did: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+          displayName: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      recordEmbed: {
+        type: 'object',
+        required: ['type', 'author', 'record'],
+        properties: {
+          type: {
+            const: 'record',
+          },
+          author: {
+            $ref: '#/$defs/appBskyGetPostThreadUser',
+          },
+          record: {
+            type: 'object',
+          },
+        },
+      },
+      externalEmbed: {
+        type: 'object',
+        required: ['type', 'uri', 'title', 'description', 'imageUri'],
+        properties: {
+          type: {
+            const: 'external',
+          },
+          uri: {
+            type: 'string',
+          },
+          title: {
+            type: 'string',
+          },
+          description: {
+            type: 'string',
+          },
+          imageUri: {
+            type: 'string',
+          },
+        },
+      },
+      unknownEmbed: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['record', 'external'],
             },
           },
         },
@@ -1449,7 +1960,7 @@ export const methodSchemas: MethodSchema[] = [
           badges: {
             type: 'array',
             items: {
-              $ref: '#/$defs/badge',
+              $ref: '#/$defs/appBskyGetProfileBadge',
             },
           },
           myState: {
@@ -1462,7 +1973,7 @@ export const methodSchemas: MethodSchema[] = [
           },
         },
         $defs: {
-          badge: {
+          appBskyGetProfileBadge: {
             type: 'object',
             required: ['uri', 'cid'],
             properties: {
@@ -1505,6 +2016,52 @@ export const methodSchemas: MethodSchema[] = [
                 format: 'date-time',
               },
             },
+          },
+        },
+      },
+    },
+    defs: {
+      badge: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+          error: {
+            type: 'string',
+          },
+          issuer: {
+            type: 'object',
+            required: ['did', 'name', 'displayName'],
+            properties: {
+              did: {
+                type: 'string',
+              },
+              name: {
+                type: 'string',
+              },
+              displayName: {
+                type: 'string',
+                maxLength: 64,
+              },
+            },
+          },
+          assertion: {
+            type: 'object',
+            required: ['type'],
+            properties: {
+              type: {
+                type: 'string',
+              },
+            },
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
           },
         },
       },
@@ -1568,6 +2125,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1639,6 +2197,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1710,6 +2269,7 @@ export const methodSchemas: MethodSchema[] = [
             },
           },
         },
+        $defs: {},
       },
     },
   },
@@ -1730,11 +2290,14 @@ export const methodSchemas: MethodSchema[] = [
             format: 'date-time',
           },
         },
+        $defs: {},
       },
     },
     output: {
       encoding: 'application/json',
-      schema: {},
+      schema: {
+        $defs: {},
+      },
     },
   },
 ]
@@ -1751,16 +2314,16 @@ export const recordSchemas: RecordSchema[] = [
         assertion: {
           oneOf: [
             {
-              $ref: '#/$defs/inviteAssertion',
+              $ref: '#/$defs/appBskyBadgeInviteAssertion',
             },
             {
-              $ref: '#/$defs/employeeAssertion',
+              $ref: '#/$defs/appBskyBadgeEmployeeAssertion',
             },
             {
-              $ref: '#/$defs/tagAssertion',
+              $ref: '#/$defs/appBskyBadgeTagAssertion',
             },
             {
-              $ref: '#/$defs/unknownAssertion',
+              $ref: '#/$defs/appBskyBadgeUnknownAssertion',
             },
           ],
         },
@@ -1773,7 +2336,7 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        inviteAssertion: {
+        appBskyBadgeInviteAssertion: {
           type: 'object',
           required: ['type'],
           properties: {
@@ -1782,7 +2345,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        employeeAssertion: {
+        appBskyBadgeEmployeeAssertion: {
           type: 'object',
           required: ['type'],
           properties: {
@@ -1791,7 +2354,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        tagAssertion: {
+        appBskyBadgeTagAssertion: {
           type: 'object',
           required: ['type', 'tag'],
           properties: {
@@ -1804,7 +2367,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        unknownAssertion: {
+        appBskyBadgeUnknownAssertion: {
           type: 'object',
           required: ['type'],
           properties: {
@@ -1813,6 +2376,51 @@ export const recordSchemas: RecordSchema[] = [
               not: {
                 enum: ['invite', 'employee', 'tag'],
               },
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      inviteAssertion: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            const: 'invite',
+          },
+        },
+      },
+      employeeAssertion: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            const: 'employee',
+          },
+        },
+      },
+      tagAssertion: {
+        type: 'object',
+        required: ['type', 'tag'],
+        properties: {
+          type: {
+            const: 'tag',
+          },
+          tag: {
+            type: 'string',
+            maxLength: 64,
+          },
+        },
+      },
+      unknownAssertion: {
+        type: 'object',
+        required: ['type'],
+        properties: {
+          type: {
+            type: 'string',
+            not: {
+              enum: ['invite', 'employee', 'tag'],
             },
           },
         },
@@ -1836,6 +2444,7 @@ export const recordSchemas: RecordSchema[] = [
           format: 'date-time',
         },
       },
+      $defs: {},
     },
   },
   {
@@ -1847,7 +2456,7 @@ export const recordSchemas: RecordSchema[] = [
       required: ['subject', 'createdAt'],
       properties: {
         subject: {
-          $ref: '#/$defs/subject',
+          $ref: '#/$defs/appBskyLikeSubject',
         },
         createdAt: {
           type: 'string',
@@ -1855,7 +2464,7 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        subject: {
+        appBskyLikeSubject: {
           type: 'object',
           required: ['uri', 'cid'],
           properties: {
@@ -1865,6 +2474,20 @@ export const recordSchemas: RecordSchema[] = [
             cid: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      subject: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
           },
         },
       },
@@ -1882,12 +2505,12 @@ export const recordSchemas: RecordSchema[] = [
         media: {
           type: 'array',
           items: {
-            $ref: '#/$defs/mediaEmbed',
+            $ref: '#/$defs/appBskyMediaEmbedMediaEmbed',
           },
         },
       },
       $defs: {
-        mediaEmbed: {
+        appBskyMediaEmbedMediaEmbed: {
           type: 'object',
           required: ['original'],
           properties: {
@@ -1895,14 +2518,14 @@ export const recordSchemas: RecordSchema[] = [
               type: 'string',
             },
             thumb: {
-              $ref: '#/$defs/mediaEmbedBlob',
+              $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
             },
             original: {
-              $ref: '#/$defs/mediaEmbedBlob',
+              $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
             },
           },
         },
-        mediaEmbedBlob: {
+        appBskyMediaEmbedMediaEmbedBlob: {
           type: 'object',
           required: ['mimeType', 'blobId'],
           properties: {
@@ -1912,6 +2535,35 @@ export const recordSchemas: RecordSchema[] = [
             blobId: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      mediaEmbed: {
+        type: 'object',
+        required: ['original'],
+        properties: {
+          alt: {
+            type: 'string',
+          },
+          thumb: {
+            $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
+          },
+          original: {
+            $ref: '#/$defs/appBskyMediaEmbedMediaEmbedBlob',
+          },
+        },
+      },
+      mediaEmbedBlob: {
+        type: 'object',
+        required: ['mimeType', 'blobId'],
+        properties: {
+          mimeType: {
+            type: 'string',
+          },
+          blobId: {
+            type: 'string',
           },
         },
       },
@@ -1930,17 +2582,17 @@ export const recordSchemas: RecordSchema[] = [
           maxLength: 256,
         },
         entities: {
-          $ref: '#/$defs/entity',
+          $ref: '#/$defs/appBskyPostEntity',
         },
         reply: {
           type: 'object',
           required: ['root', 'parent'],
           properties: {
             root: {
-              $ref: '#/$defs/postRef',
+              $ref: '#/$defs/appBskyPostPostRef',
             },
             parent: {
-              $ref: '#/$defs/postRef',
+              $ref: '#/$defs/appBskyPostPostRef',
             },
           },
         },
@@ -1950,26 +2602,14 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        postRef: {
-          type: 'object',
-          required: ['uri', 'cid'],
-          properties: {
-            uri: {
-              type: 'string',
-            },
-            cid: {
-              type: 'string',
-            },
-          },
-        },
-        entity: {
+        appBskyPostEntity: {
           type: 'array',
           items: {
             type: 'object',
             required: ['index', 'type', 'value'],
             properties: {
               index: {
-                $ref: '#/$defs/textSlice',
+                $ref: '#/$defs/appBskyPostTextSlice',
               },
               type: {
                 type: 'string',
@@ -1982,7 +2622,7 @@ export const recordSchemas: RecordSchema[] = [
             },
           },
         },
-        textSlice: {
+        appBskyPostTextSlice: {
           type: 'array',
           items: [
             {
@@ -1995,6 +2635,64 @@ export const recordSchemas: RecordSchema[] = [
           minItems: 2,
           maxItems: 2,
         },
+        appBskyPostPostRef: {
+          type: 'object',
+          required: ['uri', 'cid'],
+          properties: {
+            uri: {
+              type: 'string',
+            },
+            cid: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+    defs: {
+      postRef: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
+          },
+        },
+      },
+      entity: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['index', 'type', 'value'],
+          properties: {
+            index: {
+              $ref: '#/$defs/appBskyPostTextSlice',
+            },
+            type: {
+              type: 'string',
+              $comment: "Expected values are 'mention', 'hashtag', and 'link'.",
+            },
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      textSlice: {
+        type: 'array',
+        items: [
+          {
+            type: 'number',
+          },
+          {
+            type: 'number',
+          },
+        ],
+        minItems: 2,
+        maxItems: 2,
       },
     },
   },
@@ -2017,12 +2715,12 @@ export const recordSchemas: RecordSchema[] = [
         badges: {
           type: 'array',
           items: {
-            $ref: '#/$defs/badgeRef',
+            $ref: '#/$defs/appBskyProfileBadgeRef',
           },
         },
       },
       $defs: {
-        badgeRef: {
+        appBskyProfileBadgeRef: {
           type: 'object',
           required: ['uri', 'cid'],
           properties: {
@@ -2032,6 +2730,20 @@ export const recordSchemas: RecordSchema[] = [
             cid: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      badgeRef: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
           },
         },
       },
@@ -2046,7 +2758,7 @@ export const recordSchemas: RecordSchema[] = [
       required: ['subject', 'createdAt'],
       properties: {
         subject: {
-          $ref: '#/$defs/subject',
+          $ref: '#/$defs/appBskyRepostSubject',
         },
         createdAt: {
           type: 'string',
@@ -2054,7 +2766,7 @@ export const recordSchemas: RecordSchema[] = [
         },
       },
       $defs: {
-        subject: {
+        appBskyRepostSubject: {
           type: 'object',
           required: ['uri', 'cid'],
           properties: {
@@ -2064,6 +2776,20 @@ export const recordSchemas: RecordSchema[] = [
             cid: {
               type: 'string',
             },
+          },
+        },
+      },
+    },
+    defs: {
+      subject: {
+        type: 'object',
+        required: ['uri', 'cid'],
+        properties: {
+          uri: {
+            type: 'string',
+          },
+          cid: {
+            type: 'string',
           },
         },
       },

--- a/packages/server/src/lexicon/types/app/bsky/badge.ts
+++ b/packages/server/src/lexicon/types/app/bsky/badge.ts
@@ -3,28 +3,28 @@
 */
 export interface Record {
   assertion:
-    | InviteAssertion
-    | EmployeeAssertion
-    | TagAssertion
-    | UnknownAssertion;
+    | AppBskyBadgeInviteAssertion
+    | AppBskyBadgeEmployeeAssertion
+    | AppBskyBadgeTagAssertion
+    | AppBskyBadgeUnknownAssertion;
   subject: string;
   createdAt: string;
   [k: string]: unknown;
 }
-export interface InviteAssertion {
+export interface AppBskyBadgeInviteAssertion {
   type: 'invite';
   [k: string]: unknown;
 }
-export interface EmployeeAssertion {
+export interface AppBskyBadgeEmployeeAssertion {
   type: 'employee';
   [k: string]: unknown;
 }
-export interface TagAssertion {
+export interface AppBskyBadgeTagAssertion {
   type: 'tag';
   tag: string;
   [k: string]: unknown;
 }
-export interface UnknownAssertion {
+export interface AppBskyBadgeUnknownAssertion {
   type: string;
   [k: string]: unknown;
 }

--- a/packages/server/src/lexicon/types/app/bsky/getAuthorFeed.ts
+++ b/packages/server/src/lexicon/types/app/bsky/getAuthorFeed.ts
@@ -24,16 +24,19 @@ export interface HandlerError {
 export type HandlerOutput = HandlerError | HandlerSuccess
 
 export interface OutputSchema {
-  feed: FeedItem[];
+  feed: AppBskyGetAuthorFeedFeedItem[];
 }
-export interface FeedItem {
+export interface AppBskyGetAuthorFeedFeedItem {
   cursor: string;
   uri: string;
   cid: string;
-  author: User;
-  repostedBy?: User;
+  author: AppBskyGetAuthorFeedUser;
+  repostedBy?: AppBskyGetAuthorFeedUser;
   record: {};
-  embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
+  embed?:
+    | AppBskyGetAuthorFeedRecordEmbed
+    | AppBskyGetAuthorFeedExternalEmbed
+    | AppBskyGetAuthorFeedUnknownEmbed;
   replyCount: number;
   repostCount: number;
   likeCount: number;
@@ -43,24 +46,24 @@ export interface FeedItem {
     like?: string,
   };
 }
-export interface User {
+export interface AppBskyGetAuthorFeedUser {
   did: string;
   name: string;
   displayName?: string;
 }
-export interface RecordEmbed {
+export interface AppBskyGetAuthorFeedRecordEmbed {
   type: 'record';
-  author: User;
+  author: AppBskyGetAuthorFeedUser;
   record: {};
 }
-export interface ExternalEmbed {
+export interface AppBskyGetAuthorFeedExternalEmbed {
   type: 'external';
   uri: string;
   title: string;
   description: string;
   imageUri: string;
 }
-export interface UnknownEmbed {
+export interface AppBskyGetAuthorFeedUnknownEmbed {
   type: string;
 }
 

--- a/packages/server/src/lexicon/types/app/bsky/getHomeFeed.ts
+++ b/packages/server/src/lexicon/types/app/bsky/getHomeFeed.ts
@@ -24,16 +24,19 @@ export interface HandlerError {
 export type HandlerOutput = HandlerError | HandlerSuccess
 
 export interface OutputSchema {
-  feed: FeedItem[];
+  feed: AppBskyGetHomeFeedFeedItem[];
 }
-export interface FeedItem {
+export interface AppBskyGetHomeFeedFeedItem {
   cursor: string;
   uri: string;
   cid: string;
-  author: User;
-  repostedBy?: User;
+  author: AppBskyGetHomeFeedUser;
+  repostedBy?: AppBskyGetHomeFeedUser;
   record: {};
-  embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
+  embed?:
+    | AppBskyGetHomeFeedRecordEmbed
+    | AppBskyGetHomeFeedExternalEmbed
+    | AppBskyGetHomeFeedUnknownEmbed;
   replyCount: number;
   repostCount: number;
   likeCount: number;
@@ -43,24 +46,24 @@ export interface FeedItem {
     like?: string,
   };
 }
-export interface User {
+export interface AppBskyGetHomeFeedUser {
   did: string;
   name: string;
   displayName?: string;
 }
-export interface RecordEmbed {
+export interface AppBskyGetHomeFeedRecordEmbed {
   type: 'record';
-  author: User;
+  author: AppBskyGetHomeFeedUser;
   record: {};
 }
-export interface ExternalEmbed {
+export interface AppBskyGetHomeFeedExternalEmbed {
   type: 'external';
   uri: string;
   title: string;
   description: string;
   imageUri: string;
 }
-export interface UnknownEmbed {
+export interface AppBskyGetHomeFeedUnknownEmbed {
   type: string;
 }
 

--- a/packages/server/src/lexicon/types/app/bsky/getNotifications.ts
+++ b/packages/server/src/lexicon/types/app/bsky/getNotifications.ts
@@ -23,9 +23,9 @@ export interface HandlerError {
 export type HandlerOutput = HandlerError | HandlerSuccess
 
 export interface OutputSchema {
-  notifications: Notification[];
+  notifications: AppBskyGetNotificationsNotification[];
 }
-export interface Notification {
+export interface AppBskyGetNotificationsNotification {
   uri: string;
   cid: string;
   author: {

--- a/packages/server/src/lexicon/types/app/bsky/getPostThread.ts
+++ b/packages/server/src/lexicon/types/app/bsky/getPostThread.ts
@@ -23,17 +23,20 @@ export interface HandlerError {
 export type HandlerOutput = HandlerError | HandlerSuccess
 
 export interface OutputSchema {
-  thread: Post;
+  thread: AppBskyGetPostThreadPost;
 }
-export interface Post {
+export interface AppBskyGetPostThreadPost {
   uri: string;
   cid: string;
-  author: User;
+  author: AppBskyGetPostThreadUser;
   record: {};
-  embed?: RecordEmbed | ExternalEmbed | UnknownEmbed;
-  parent?: Post;
+  embed?:
+    | AppBskyGetPostThreadRecordEmbed
+    | AppBskyGetPostThreadExternalEmbed
+    | AppBskyGetPostThreadUnknownEmbed;
+  parent?: AppBskyGetPostThreadPost;
   replyCount: number;
-  replies?: Post[];
+  replies?: AppBskyGetPostThreadPost[];
   likeCount: number;
   repostCount: number;
   indexedAt: string;
@@ -42,24 +45,24 @@ export interface Post {
     like?: string,
   };
 }
-export interface User {
+export interface AppBskyGetPostThreadUser {
   did: string;
   name: string;
   displayName?: string;
 }
-export interface RecordEmbed {
+export interface AppBskyGetPostThreadRecordEmbed {
   type: 'record';
-  author: User;
+  author: AppBskyGetPostThreadUser;
   record: {};
 }
-export interface ExternalEmbed {
+export interface AppBskyGetPostThreadExternalEmbed {
   type: 'external';
   uri: string;
   title: string;
   description: string;
   imageUri: string;
 }
-export interface UnknownEmbed {
+export interface AppBskyGetPostThreadUnknownEmbed {
   type: string;
 }
 

--- a/packages/server/src/lexicon/types/app/bsky/getProfile.ts
+++ b/packages/server/src/lexicon/types/app/bsky/getProfile.ts
@@ -29,12 +29,12 @@ export interface OutputSchema {
   followersCount: number;
   followsCount: number;
   postsCount: number;
-  badges: Badge[];
+  badges: AppBskyGetProfileBadge[];
   myState?: {
     follow?: string,
   };
 }
-export interface Badge {
+export interface AppBskyGetProfileBadge {
   uri: string;
   cid: string;
   error?: string;

--- a/packages/server/src/lexicon/types/app/bsky/like.ts
+++ b/packages/server/src/lexicon/types/app/bsky/like.ts
@@ -2,11 +2,11 @@
 * GENERATED CODE - DO NOT MODIFY
 */
 export interface Record {
-  subject: Subject;
+  subject: AppBskyLikeSubject;
   createdAt: string;
   [k: string]: unknown;
 }
-export interface Subject {
+export interface AppBskyLikeSubject {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/server/src/lexicon/types/app/bsky/mediaEmbed.ts
+++ b/packages/server/src/lexicon/types/app/bsky/mediaEmbed.ts
@@ -2,16 +2,16 @@
 * GENERATED CODE - DO NOT MODIFY
 */
 export interface Record {
-  media: MediaEmbed[];
+  media: AppBskyMediaEmbedMediaEmbed[];
   [k: string]: unknown;
 }
-export interface MediaEmbed {
+export interface AppBskyMediaEmbedMediaEmbed {
   alt?: string;
-  thumb?: MediaEmbedBlob;
-  original: MediaEmbedBlob;
+  thumb?: AppBskyMediaEmbedMediaEmbedBlob;
+  original: AppBskyMediaEmbedMediaEmbedBlob;
   [k: string]: unknown;
 }
-export interface MediaEmbedBlob {
+export interface AppBskyMediaEmbedMediaEmbedBlob {
   mimeType: string;
   blobId: string;
   [k: string]: unknown;

--- a/packages/server/src/lexicon/types/app/bsky/post.ts
+++ b/packages/server/src/lexicon/types/app/bsky/post.ts
@@ -5,9 +5,9 @@
  * @minItems 2
  * @maxItems 2
  */
-export type TextSlice = [number, number]
-export type Entity = {
-  index: TextSlice,
+export type AppBskyPostTextSlice = [number, number]
+export type AppBskyPostEntity = {
+  index: AppBskyPostTextSlice,
   type: string,
   value: string,
   [k: string]: unknown,
@@ -15,16 +15,16 @@ export type Entity = {
 
 export interface Record {
   text: string;
-  entities?: Entity;
+  entities?: AppBskyPostEntity;
   reply?: {
-    root: PostRef,
-    parent: PostRef,
+    root: AppBskyPostPostRef,
+    parent: AppBskyPostPostRef,
     [k: string]: unknown,
   };
   createdAt: string;
   [k: string]: unknown;
 }
-export interface PostRef {
+export interface AppBskyPostPostRef {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/server/src/lexicon/types/app/bsky/profile.ts
+++ b/packages/server/src/lexicon/types/app/bsky/profile.ts
@@ -4,10 +4,10 @@
 export interface Record {
   displayName: string;
   description?: string;
-  badges?: BadgeRef[];
+  badges?: AppBskyProfileBadgeRef[];
   [k: string]: unknown;
 }
-export interface BadgeRef {
+export interface AppBskyProfileBadgeRef {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/server/src/lexicon/types/app/bsky/repost.ts
+++ b/packages/server/src/lexicon/types/app/bsky/repost.ts
@@ -2,11 +2,11 @@
 * GENERATED CODE - DO NOT MODIFY
 */
 export interface Record {
-  subject: Subject;
+  subject: AppBskyRepostSubject;
   createdAt: string;
   [k: string]: unknown;
 }
-export interface Subject {
+export interface AppBskyRepostSubject {
   uri: string;
   cid: string;
   [k: string]: unknown;

--- a/packages/server/tests/_util.ts
+++ b/packages/server/tests/_util.ts
@@ -6,7 +6,8 @@ import { CID } from 'multiformats/cid'
 import getPort from 'get-port'
 import * as uint8arrays from 'uint8arrays'
 import server, { ServerConfig, Database, App } from '../src/index'
-import { AppBskyGetAuthorFeed, AppBskyGetHomeFeed } from '@adxp/api'
+import * as GetAuthorFeed from '../src/lexicon/types/app/bsky/getAuthorFeed'
+import * as GetHomeFeed from '../src/lexicon/types/app/bsky/getHomeFeed'
 
 const USE_TEST_SERVER = true
 
@@ -146,7 +147,8 @@ export const forSnapshot = (obj: unknown) => {
 
 // Feed testing utils
 
-type FeedItem = AppBskyGetAuthorFeed.FeedItem & AppBskyGetHomeFeed.FeedItem
+type FeedItem = GetAuthorFeed.AppBskyGetAuthorFeedFeedItem &
+  GetHomeFeed.AppBskyGetHomeFeedFeedItem
 
 export const getCursors = (feed: FeedItem[]) => feed.map((item) => item.cursor)
 

--- a/packages/server/tests/views/home-feed.test.ts
+++ b/packages/server/tests/views/home-feed.test.ts
@@ -10,7 +10,7 @@ import {
 import { SeedClient } from '../seeds/client'
 import basicSeed from '../seeds/basic'
 import { FeedAlgorithm } from '../../src/api/app/bsky/util/feed'
-import { FeedItem } from '@adxp/api/src/types/app/bsky/getHomeFeed'
+import { AppBskyGetHomeFeedFeedItem as FeedItem } from '@adxp/api/src/types/app/bsky/getHomeFeed'
 
 describe('pds home feed views', () => {
   let client: AdxServiceClient

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,6 +4715,11 @@ follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.8, fo
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+foreach@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.6.tgz#87bcc8a1a0e74000ff2bf9802110708cfb02eb6e"
+  integrity sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -6070,6 +6075,13 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-pointer@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.2.tgz#f97bd7550be5e9ea901f8c9264c9d436a22a93cd"
+  integrity sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==
+  dependencies:
+    foreach "^2.0.4"
 
 json-schema-to-typescript@^11.0.2:
   version "11.0.2"


### PR DESCRIPTION
- Fixes lex $ref JSON-pointers to point to the _top_ of the document, not the JSON schema using the $ref
- Updates the lexicon document format:
  - New toplevel `defs` field for shared definitions
  - Method input/output bodies now have an optional description
- Adds the ability to reference other lexicon documents using `lex:{nsid}`

Sadly the generated code is a little uglier now (types had to get more specific).