### PR TITLE
Repo metadata

### DIFF
--- a/packages/repo/src/repo.ts
+++ b/packages/repo/src/repo.ts
@@ -2,7 +2,7 @@ import { CID } from 'multiformats/cid'
 import { CarReader, CarWriter } from '@ipld/car'
 import { BlockWriter } from '@ipld/car/lib/writer-browser'
 
-import { RepoRoot, Commit, def, BatchWrite, DataStore } from './types'
+import { RepoRoot, Commit, def, BatchWrite, DataStore, RepoMeta } from './types'
 import { check, streamToArray, TID } from '@adxp/common'
 import IpldStore, { AllowedIpldVal } from './blockstore/ipld-store'
 import * as auth from '@adxp/auth'
@@ -15,6 +15,7 @@ export class Repo {
   data: DataStore
   commit: Commit
   root: RepoRoot
+  meta: RepoMeta
   cid: CID
   authStore: auth.AuthStore | null
   verifier: auth.Verifier
@@ -24,6 +25,7 @@ export class Repo {
     data: DataStore
     commit: Commit
     root: RepoRoot
+    meta: RepoMeta
     cid: CID
     authStore: auth.AuthStore | undefined
     verifier: auth.Verifier | undefined
@@ -32,6 +34,7 @@ export class Repo {
     this.data = params.data
     this.commit = params.commit
     this.root = params.root
+    this.meta = params.meta
     this.cid = params.cid
     this.authStore = params.authStore || null
     this.verifier = params.verifier ?? new auth.Verifier()
@@ -55,8 +58,15 @@ export class Repo {
     const data = await MST.create(blockstore)
     const dataCid = await data.save()
 
-    const root: RepoRoot = {
+    const meta: RepoMeta = {
       did,
+      version: 1,
+      datastore: 'mst',
+    }
+    const metaCid = await blockstore.put(meta)
+
+    const root: RepoRoot = {
+      meta: metaCid,
       prev: null,
       auth_token: tokenCid,
       data: dataCid,
@@ -76,6 +86,7 @@ export class Repo {
       data,
       commit,
       root,
+      meta,
       cid,
       authStore,
       verifier,
@@ -90,13 +101,15 @@ export class Repo {
   ) {
     const commit = await blockstore.get(cid, def.commit)
     const root = await blockstore.get(commit.root, def.repoRoot)
+    const meta = await blockstore.get(root.meta, def.repoMeta)
     const data = await MST.load(blockstore, root.data)
-    log.info({ did: root.did }, 'loaded repo for')
+    log.info({ did: meta.did }, 'loaded repo for')
     return new Repo({
       blockstore,
       data,
       commit,
       root,
+      meta,
       cid,
       authStore,
       verifier,
@@ -130,7 +143,7 @@ export class Repo {
   }
 
   did(): string {
-    return this.root.did
+    return this.meta.did
   }
 
   getCollection(name: string): Collection {
@@ -158,7 +171,7 @@ export class Repo {
       : await this.ucanForOperation(updatedData)
     const dataCid = await updatedData.save()
     const root: RepoRoot = {
-      did: this.did(),
+      meta: this.root.meta,
       prev: currentCommit,
       auth_token: tokenCid,
       data: dataCid,
@@ -307,6 +320,10 @@ export class Repo {
     for (const commit of commitPath.slice(1)) {
       const nextRepo = await Repo.load(this.blockstore, commit)
       const diff = await prevRepo.data.diff(nextRepo.data)
+
+      if (!nextRepo.root.meta.equals(prevRepo.root.meta)) {
+        throw new Error('Not supported: repo metadata updated')
+      }
 
       let didForSignature: string
       if (nextRepo.root.auth_token) {

--- a/packages/repo/src/repo.ts
+++ b/packages/repo/src/repo.ts
@@ -433,6 +433,7 @@ export class Repo {
     const root = await this.blockstore.get(commit.root, def.repoRoot)
     await this.blockstore.addToCar(car, this.cid)
     await this.blockstore.addToCar(car, commit.root)
+    await this.blockstore.addToCar(car, root.meta)
     if (root.auth_token) {
       await this.blockstore.addToCar(car, root.auth_token)
     }
@@ -459,6 +460,7 @@ export class Repo {
       const nextHead = await Repo.load(this.blockstore, commit)
       await this.blockstore.addToCar(car, nextHead.cid)
       await this.blockstore.addToCar(car, nextHead.commit.root)
+      await this.blockstore.addToCar(car, nextHead.root.meta)
       if (nextHead.root.auth_token) {
         await this.blockstore.addToCar(car, nextHead.root.auth_token)
       }

--- a/packages/repo/src/types.ts
+++ b/packages/repo/src/types.ts
@@ -11,8 +11,15 @@ const strToTid = z
   .refine(TID.is, { message: 'Not a valid TID' })
   .transform(TID.fromStr)
 
-const repoRoot = z.object({
+const repoMeta = z.object({
   did: z.string(),
+  version: z.number(),
+  datastore: z.string(),
+})
+export type RepoMeta = z.infer<typeof repoMeta>
+
+const repoRoot = z.object({
+  meta: common.cid,
   prev: common.cid.nullable(),
   auth_token: common.cid.nullable(),
   data: common.cid,
@@ -55,6 +62,7 @@ export const def = {
   ...common,
   tid,
   strToTid,
+  repoMeta,
   repoRoot,
   commit,
   batchWrite,

--- a/packages/repo/tests/repo.test.ts
+++ b/packages/repo/tests/repo.test.ts
@@ -19,6 +19,12 @@ describe('Repo', () => {
     repo = await Repo.create(blockstore, await authStore.did(), authStore)
   })
 
+  it('has proper metadat', async () => {
+    expect(repo.meta.did).toEqual(await authStore.did())
+    expect(repo.meta.version).toBe(1)
+    expect(repo.meta.datastore).toBe('mst')
+  })
+
   it('does basic operations', async () => {
     const collection = repo.getCollection('com.example.posts')
 
@@ -74,5 +80,8 @@ describe('Repo', () => {
     )
 
     await util.checkRepo(reloadedRepo, repoData)
+    expect(repo.meta.did).toEqual(await authStore.did())
+    expect(repo.meta.version).toBe(1)
+    expect(repo.meta.datastore).toBe('mst')
   })
 })

--- a/packages/repo/tests/repo.test.ts
+++ b/packages/repo/tests/repo.test.ts
@@ -19,7 +19,7 @@ describe('Repo', () => {
     repo = await Repo.create(blockstore, await authStore.did(), authStore)
   })
 
-  it('has proper metadat', async () => {
+  it('has proper metadata', async () => {
     expect(repo.meta.did).toEqual(await authStore.did())
     expect(repo.meta.version).toBe(1)
     expect(repo.meta.datastore).toBe('mst')

--- a/packages/repo/tests/sync.test.ts
+++ b/packages/repo/tests/sync.test.ts
@@ -36,13 +36,7 @@ describe('Sync', () => {
 
   it('syncs a repo that is starting from scratch', async () => {
     repoData = await util.fillRepo(aliceRepo, 100)
-    try {
-      const car = await aliceRepo.getFullHistory()
-    } catch (err) {
-      const contents = await aliceBlockstore.getContents()
-      console.log(contents)
-      throw err
-    }
+    await aliceRepo.getFullHistory()
 
     const car = await aliceRepo.getFullHistory()
     bobRepo = await Repo.fromCarFile(car, bobBlockstore)
@@ -78,7 +72,7 @@ describe('Sync', () => {
     const auth_token = await aliceBlockstore.put(auth.encodeUcan(badUcan))
     const dataCid = await updatedData.save()
     const root: RepoRoot = {
-      did: aliceRepo.did(),
+      meta: aliceRepo.root.meta,
       prev: aliceRepo.cid,
       auth_token,
       data: dataCid,
@@ -105,7 +99,7 @@ describe('Sync', () => {
     const auth_token = await aliceRepo.ucanForOperation(updatedData)
     const dataCid = await updatedData.save()
     const root: RepoRoot = {
-      did: aliceRepo.did(),
+      meta: aliceRepo.root.meta,
       prev: aliceRepo.cid,
       auth_token,
       data: dataCid,


### PR DESCRIPTION
Split metadata out into a node off of the root.

```ts
// type
type RepoMeta = {
  did: string
  version: number
  datastore: string
}

// currentValues
const meta = {
  did: rootUserDid,
  version: 1,
  datastore: 'mst',
}
```

This is mainly to future-proof the repo. For now, we just enforce that a repo's metadata can't ever change.